### PR TITLE
Fix for webpack moduleId resolve.

### DIFF
--- a/moduleId-fix.js
+++ b/moduleId-fix.js
@@ -1,0 +1,9 @@
+// using: regex, capture groups, and capture group variables.
+var moduleIdRegex = /moduleId:.*$/gm;
+
+module.exports = function(source, sourcemap) {
+  var newSource = source.replace(moduleIdRegex, function(match, url) {
+                   return "";
+  });
+  return newSource;
+};

--- a/vendor.ts.angular.template
+++ b/vendor.ts.angular.template
@@ -9,6 +9,4 @@ require('@angular/forms');
 require('@angular/http');
 require('@angular/router');
 
-require('nativescript-angular/platform');
-require('nativescript-angular/forms');
-require('nativescript-angular/router');
+require('nativescript-angular');

--- a/webpack.common.js.template
+++ b/webpack.common.js.template
@@ -25,6 +25,11 @@ module.exports = function(platform, destinationApp) {
             filename: "[name].js",
             jsonpFunction: "nativescriptJsonp"
         },
+        resolveLoader: {
+            alias: {
+                "moduleId-fix": path.join(__dirname, "node_modules/nativescript-dev-webpack/moduleId-fix.js")
+            }
+        },
         resolve: {
             //Resolve platform-specific modules like module.android.js
             extensions: [
@@ -59,7 +64,8 @@ module.exports = function(platform, destinationApp) {
                     test: /\.ts$/,
                     loaders: [
                         "awesome-typescript-loader",
-                        "angular2-template-loader"
+                        "angular2-template-loader",
+                        "moduleId-fix"
                     ]
                 },
                 {


### PR DESCRIPTION
Added simple regex to remove `moduleId` declarations from angular components in webpack scenario.