### PR TITLE
feat: add support for tsc@2.1 and ng@2.4

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -53,10 +53,10 @@ configureDevDependencies(packageJson, function (add) {
     add("extract-text-webpack-plugin", "~2.0.0-beta.4");
 
     if (isAngular) {
-        add("@angular/compiler-cli", "2.3.1");
+        add("@angular/compiler-cli", "2.4.3");
         add("@ngtools/webpack", "1.2.1");
-        add("typescript", "~2.0.10");
-        add("htmlparser2", "^3.9.2");
+        add("typescript", "^2.0.10");
+        add("htmlparser2", "~3.9.2");
     } else {
         add("awesome-typescript-loader", "~3.0.0-beta.9");
     }

--- a/tsconfig.aot.json.template
+++ b/tsconfig.aot.json.template
@@ -9,8 +9,35 @@
     "removeComments": false,
     "noImplicitAny": false,
     "suppressImplicitAnyIndexErrors": true,
-    "types": []
-  },
+    "types": [],
+    "baseUrl": ".",
+    "paths": {
+      "ui/*": ["node_modules/tns-core-modules/ui/*"],
+      "platform": ["node_modules/tns-core-modules/platform"],
+      "image-source": ["node_modules/tns-core-modules/image-source"],
+      "xml": ["node_modules/tns-core-modules/xml"],
+      "xhr": ["node_modules/tns-core-modules/xhr"],
+      "text": ["node_modules/tns-core-modules/text"],
+      "data": ["node_modules/tns-core-modules/data"],
+      "fetch": ["node_modules/tns-core-modules/fetch"],
+      "trace": ["node_modules/tns-core-modules/trace"],
+      "fps-meter": ["node_modules/tns-core-modules/fps-meter"],
+      "color": ["node_modules/tns-core-modules/color"],
+      "application-settings": ["node_modules/tns-core-modules/application-settings"],
+      "http": ["node_modules/tns-core-modules/http"],
+      "camera": ["node_modules/tns-core-modules/camera"],
+      "console": ["node_modules/tns-core-modules/console"],
+      "timer": ["node_modules/tns-core-modules/timer"],
+      "utils": ["node_modules/tns-core-modules/utils"],
+      "location": ["node_modules/tns-core-modules/location"],
+      "file-system": ["node_modules/tns-core-modules/file-system"],
+      "application": ["node_modules/tns-core-modules/application"],
+      "image-asset": ["node_modules/tns-core-modules/image-asset"],
+      "connectivity": ["node_modules/tns-core-modules/connectivity"],
+      "globals": ["node_modules/tns-core-modules/globals"]
+
+    }
+   },
   "exclude": [
       "node_modules",
       "platforms"


### PR DESCRIPTION
Angular-compiler requires the `paths` option set in `tsconfig` in order to resolve modules of the type `ui/page`, `ui/frame`, `platform`, etc. The `paths` option is available in Typescript ^2.1. 
This should be released when the NativeScript platforms' support for Typescript@2.1 is released (`NativeScript@2.5`).