### PR TITLE
fix: exclude from mangling EditableTextBase

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,6 +138,7 @@ exports.uglifyMangleExcludes = [
     "ActivityIndicator",
     "Button",
     "DatePicker",
+    "EditableTextBase",
     "Image",
     "Label",
     "ListPicker",


### PR DESCRIPTION
Uglify shouldn't mangle the TextBase descendant classes.

fixes https://github.com/NativeScript/sample-Groceries/pull/202