### PR TITLE
fix: run `tns-xml-loader` before `@ngtools` loader

### DIFF
--- a/tns-xml-loader.js
+++ b/tns-xml-loader.js
@@ -61,7 +61,10 @@ function getTemplateSource(path, source) {
         return source;
     } else if (isComponent(path)) {
         const templateMatcher = /template\s*:\s*([`'"])((.|\n)*?)\1/;
-        return templateMatcher.test(source) ? source.replace(templateMatcher, "$2") : "";
+        let match = templateMatcher.exec(source);
+
+        return match ? match[2] : "";
+
     } else {
         throw new Error(`The NativeScript XML loader must be used with HTML, XML or TypeScript files`);
     }

--- a/webpack.common.js.angular.template
+++ b/webpack.common.js.angular.template
@@ -135,9 +135,9 @@ module.exports = function (platform, destinationApp) {
                 {
                     test: /\.ts$/,
                     loaders: [
-                        "nativescript-dev-webpack/tns-xml-loader",
                         "nativescript-dev-webpack/tns-aot-loader",
                         "@ngtools/webpack",
+                        "nativescript-dev-webpack/tns-xml-loader",
                     ]
                 },
                 // SASS support


### PR DESCRIPTION
This is needed due to changes in the behaviour of `@ngtools/webpack` v1.2.4.
Also a little change in the template extraction from `ts` component.

fixes #64