### PR TITLE
Extend existing tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-dev-webpack",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "main": "index",
   "description": "",
   "homepage": "http://www.telerik.com",

--- a/tsconfig.aot.json.template
+++ b/tsconfig.aot.json.template
@@ -1,15 +1,6 @@
 {
+  "extend": "./tsconfig",
   "compilerOptions": {
-    "target": "es5",
-    "module": "es2015",
-    "moduleResolution": "node",
-    "sourceMap": true,
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "removeComments": false,
-    "noImplicitAny": false,
-    "suppressImplicitAnyIndexErrors": true,
-    "types": [],
     "baseUrl": ".",
     "paths": {
       "ui/*": ["node_modules/tns-core-modules/ui/*"],
@@ -35,13 +26,8 @@
       "image-asset": ["node_modules/tns-core-modules/image-asset"],
       "connectivity": ["node_modules/tns-core-modules/connectivity"],
       "globals": ["node_modules/tns-core-modules/globals"]
-
     }
-   },
-  "exclude": [
-      "node_modules",
-      "platforms"
-  ],
+  },
   "angularCompilerOptions": {
     "skipMetadataEmit": true,
     "genDir": "./"


### PR DESCRIPTION
Reuse tsconfig.json from the client project. Force as few TS options as possible.

Also removes the need to have matching `"lib"` settings and allows us to build tns-core-modules@3.0.0 projects.