### PR TITLE
fix(scripts): correctly execute ns-bundle for windows

### DIFF
--- a/bin/ns-bundle
+++ b/bin/ns-bundle
@@ -102,7 +102,7 @@ function getCommand(flags) {
 
 function spawnChildProcess(command, ...args) {
     return new Promise((resolve, reject) => {
-            const childProcess = spawn(command, args,  { stdio: "inherit", pwd: PROJECT_DIR });
+            const childProcess = spawn(command, args,  { stdio: "inherit", pwd: PROJECT_DIR, shell: true });
 
             childProcess.on("close", (code) => {
                 if (code === 0) {


### PR DESCRIPTION
Spawning child processes requires "shell: true" for windows.

Fixes https://github.com/NativeScript/NativeScript/issues/3715