### PR TITLE
fix(tsconfig): add "exclude" property to aot config

### DIFF
--- a/tsconfig.aot.json.template
+++ b/tsconfig.aot.json.template
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
+    "baseUrl": ".",
     "paths": {
       "ui/*": ["node_modules/tns-core-modules/ui/*"],
       "platform": ["node_modules/tns-core-modules/platform"],
@@ -27,6 +28,10 @@
       "globals": ["node_modules/tns-core-modules/globals"]
     }
   },
+  "exclude": [
+    "node_modules",
+    "platforms"
+  ],
   "angularCompilerOptions": {
     "skipMetadataEmit": true,
     "genDir": "./"


### PR DESCRIPTION
The "exclude" property isn't properly inherited from the base
configuration ("tsconfig.json") so we need to explicitly specify it.
This caused the angular compiler to try to parse the `platforms` folder
and eventually fail.

fixes #101