### PR TITLE
feat(ns-bundle): app can be just prepared and bundled now

### DIFF
--- a/bin/ns-bundle
+++ b/bin/ns-bundle
@@ -15,7 +15,7 @@ const flags = npmArgs.filter(a => a.startsWith("--")).map(a => a.substring(2));
 const options = getOptions(flags);
 
 function getTnsArgs(args) {
-    let other = [
+    const other = [
         "run",
         "ns-bundle",
         "--android",
@@ -36,16 +36,20 @@ function escape(arg) {
 execute(options);
 
 function execute(options) {
-    let commands = [
-        () => runTns(options.command, options.platform),
-    ];
+    let commands = [];
 
     if (options.bundle) {
-        commands = [
-            () => prepare(options.platform),
-            () => webpack(options.platform),
-            ...commands
-        ];
+        commands.push(() => clearPlatform(options.platform));
+        commands.push(() => webpack(options.platform));
+    }
+
+    // If "build-app" or "start-app" is specified,
+    // the respective command should be run last.
+    // Otherwise, the app should be just prepared.
+    if (options.command) {
+        commands.push(() => runTns(options.command, options.platform));
+    } else {
+        commands.shift(() => runTns("prepare", options.platform))
     }
 
     return commands.reduce((current, next) => current.then(next), Promise.resolve());
@@ -61,7 +65,7 @@ function webpack(platform) {
     });
 }
 
-function prepare(platform) {
+function clearPlatform(platform) {
     return removePlatform(platform)
         .then(() => addPlatform(platform));
 }
@@ -128,8 +132,6 @@ function getCommand(flags) {
         return "run";
     } else if (flags.includes("build-app")) {
         return "build";
-    } else {
-        throwError({message: "You must provide either --start-app, or --build-app flag!"});
     }
 }
 


### PR DESCRIPTION
When this is released, developers will be able to prepare and bundle the project and then release it from xcode. This can be done with the following command:
`npm run ns-bundle --android/ios`
If you don't pass `--start-app` or `--build-app` to ns-bundle, the
project will be only prepared and bundled now.

Related to https://github.com/NativeScript/nativescript-cli/issues/2716, https://github.com/NativeScript/nativescript-cli/issues/2702