### PR TITLE
fix(template): ship bundle with empty `tns-java-classes.js` chunk

### DIFF
--- a/webpack.common.js.angular.template
+++ b/webpack.common.js.angular.template
@@ -21,9 +21,15 @@ module.exports = function (platform, destinationApp) {
 
     var plugins = [
         new ExtractTextPlugin("app.css"),
-        // Vendor libs go to the vendor.js chunk
         new webpack.optimize.CommonsChunkPlugin({
-            name: ["vendor"]
+            name: [
+                // Vendor libs go to the vendor.js chunk
+                "vendor",
+
+                // Compatibility workaround with NativeScript 2.5 Android runtime
+                // https://github.com/NativeScript/NativeScript/issues/3947
+                "tns-java-classes",
+            ],
         }),
         // Define useful constants like TNS_WEBPACK
         new webpack.DefinePlugin({

--- a/webpack.common.js.javascript.template
+++ b/webpack.common.js.javascript.template
@@ -22,7 +22,14 @@ module.exports = function (platform, destinationApp) {
         new ExtractTextPlugin("app.css"),
         // Vendor libs go to the vendor.js chunk
         new webpack.optimize.CommonsChunkPlugin({
-            name: ["vendor"]
+            name: [
+                // Vendor libs go to the vendor.js chunk
+                "vendor",
+
+                // Compatibility workaround with NativeScript 2.5 Android runtime
+                // https://github.com/NativeScript/NativeScript/issues/3947
+                "tns-java-classes",
+            ],
         }),
         // Define useful constants like TNS_WEBPACK
         new webpack.DefinePlugin({

--- a/webpack.common.js.typescript.template
+++ b/webpack.common.js.typescript.template
@@ -22,7 +22,14 @@ module.exports = function (platform, destinationApp) {
         new ExtractTextPlugin("app.css"),
         // Vendor libs go to the vendor.js chunk
         new webpack.optimize.CommonsChunkPlugin({
-            name: ["vendor"]
+            name: [
+                // Vendor libs go to the vendor.js chunk
+                "vendor",
+
+                // Compatibility workaround with NativeScript 2.5 Android runtime
+                // https://github.com/NativeScript/NativeScript/issues/3947
+                "tns-java-classes",
+            ],
         }),
         // Define useful constants like TNS_WEBPACK
         new webpack.DefinePlugin({


### PR DESCRIPTION
This is required for compatibility reasons (NativeScript 2.5).
When a non-webpacked NativeScript application is deployed to phone, the apk
contains a `tns-java-classes.js` file. If that file is present, it is
dynamically loaded by the Android runtime at startup.
Webpacked NativeScript applications didn't contain that file as it is
not needed. But when the application is deployed to phone, the previous
`tns-java-classes.js` file is not removed from the app folder on the
phone. That causes the Android runtime to try load the file and fail.
Since this commit, all webpacked NativeScript apps will be shipped with
an empty `tns-java-classes.js` file which is harmless and is used to
override the existing file left from previous deployment.

related to https://github.com/NativeScript/NativeScript/issues/3613, https://github.com/NativeScript/NativeScript/issues/3947