### PR TITLE
fix(template): include platform specific files in bundle first

### DIFF
--- a/webpack.common.js.angular.template
+++ b/webpack.common.js.angular.template
@@ -81,13 +81,13 @@ module.exports = function (platform, destinationApp) {
         resolve: {
             // Resolve platform-specific modules like module.android.js
             extensions: [
+                "." + platform + ".ts",
+                "." + platform + ".js",
+                "." + platform + ".css",
                 ".aot.ts",
                 ".ts",
                 ".js",
                 ".css",
-                "." + platform + ".ts",
-                "." + platform + ".js",
-                "." + platform + ".css",
             ],
             // Resolve {N} system modules from tns-core-modules
             modules: [

--- a/webpack.common.js.javascript.template
+++ b/webpack.common.js.javascript.template
@@ -72,10 +72,10 @@ module.exports = function (platform, destinationApp) {
         resolve: {
             // Resolve platform-specific modules like module.android.js
             extensions: [
-                ".js",
-                ".css",
                 "." + platform + ".js",
                 "." + platform + ".css",
+                ".js",
+                ".css",
             ],
             // Resolve {N} system modules from tns-core-modules
             modules: [

--- a/webpack.common.js.typescript.template
+++ b/webpack.common.js.typescript.template
@@ -72,12 +72,12 @@ module.exports = function (platform, destinationApp) {
         resolve: {
             // Resolve platform-specific modules like module.android.js
             extensions: [
-                ".ts",
-                ".js",
-                ".css",
                 "." + platform + ".ts",
                 "." + platform + ".js",
                 "." + platform + ".css",
+                ".ts",
+                ".js",
+                ".css",
             ],
             // Resolve {N} system modules from tns-core-modules
             modules: [


### PR DESCRIPTION
NativeScript UI chart directives wasn't included in the bundle when webpacking. This change should fix the problem as the platform specific files are now preferred over the plain ones.
Here's a simple project that demonstrates the usage of chart with webpack: https://github.com/sis0k0/chart.

fixes #31, fixes https://github.com/telerik/nativescript-ui-feedback/issues/140