### PR TITLE
fix(template): create empty `tns-java-classes.js` internally

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,9 +52,18 @@ exports.GenerateBundleStarterPlugin.prototype = {
         compiler.plugin("emit", function (compilation, cb) {
             compilation.assets["package.json"] = plugin.generatePackageJson();
             compilation.assets["starter.js"] = plugin.generateStarterModule();
+            plugin.generateTnsJavaClasses(compilation);
 
             cb();
         });
+    },
+    generateTnsJavaClasses: function (compilation) {
+        const path = compilation.compiler.outputPath;
+        const isAndroid = path.indexOf("android") > -1;
+
+        if (isAndroid) {
+            compilation.assets["tns-java-classes.js"] = new sources.RawSource("");
+        }
     },
     generatePackageJson: function () {
         var packageJsonPath = path.join(this.webpackContext, "package.json");

--- a/webpack.common.js.angular.template
+++ b/webpack.common.js.angular.template
@@ -19,19 +19,11 @@ module.exports = function (platform, destinationApp) {
     // app.css bundle
     entry["app.css"] = "./app.css";
 
-    // Vendor libs go to the vendor.js chunk
-    var commonsChunkNames = ["vendor"];
-
-    // Compatibility workaround with NativeScript 2.5 Android runtime
-    // https://github.com/NativeScript/NativeScript/issues/3947
-     if (platform === "android") {
-        commonsChunkNames.push("tns-java-classes");
-    }
-
     var plugins = [
         new ExtractTextPlugin("app.css"),
         new webpack.optimize.CommonsChunkPlugin({
-            name: commonsChunkNames
+            // Vendor libs go to the vendor.js chunk
+            name: ["vendor"]
         }),
         // Define useful constants like TNS_WEBPACK
         new webpack.DefinePlugin({

--- a/webpack.common.js.javascript.template
+++ b/webpack.common.js.javascript.template
@@ -18,19 +18,10 @@ module.exports = function (platform, destinationApp) {
     // app.css bundle
     entry["app.css"] = "./app.css";
 
-    // Vendor libs go to the vendor.js chunk
-    var commonsChunkNames = ["vendor"];
-
-    // Compatibility workaround with NativeScript 2.5 Android runtime
-    // https://github.com/NativeScript/NativeScript/issues/3947
-     if (platform === "android") {
-        commonsChunkNames.push("tns-java-classes");
-    }
-
     var plugins = [
         new ExtractTextPlugin("app.css"),
         new webpack.optimize.CommonsChunkPlugin({
-            name: commonsChunkNames
+            name: ["vendor"]
         }),
         // Define useful constants like TNS_WEBPACK
         new webpack.DefinePlugin({

--- a/webpack.common.js.typescript.template
+++ b/webpack.common.js.typescript.template
@@ -18,19 +18,10 @@ module.exports = function (platform, destinationApp) {
     // app.css bundle
     entry["app.css"] = "./app.css";
 
-    // Vendor libs go to the vendor.js chunk
-    var commonsChunkNames = ["vendor"];
-
-    // Compatibility workaround with NativeScript 2.5 Android runtime
-    // https://github.com/NativeScript/NativeScript/issues/3947
-     if (platform === "android") {
-        commonsChunkNames.push("tns-java-classes");
-    }
-
     var plugins = [
         new ExtractTextPlugin("app.css"),
         new webpack.optimize.CommonsChunkPlugin({
-            name: commonsChunkNames
+            name: ["vendor"]
         }),
         // Define useful constants like TNS_WEBPACK
         new webpack.DefinePlugin({


### PR DESCRIPTION
The tns-java-classes.js that is required for NativeScript 2.5 Android
builds is now create internally (GenerateStarterPlugin) instead as part
of CommonChunksPlugin.