### PR TITLE
fix(template): disable minification of css by css-loader

### DIFF
--- a/prepublish/common/rules.js
+++ b/prepublish/common/rules.js
@@ -13,7 +13,10 @@ module.exports = `
                     loader: "resolve-url-loader",
                     options: { silent: true },
                 },
-                "nativescript-css-loader",
+                {
+                    loader: "nativescript-css-loader",
+                    options: { minimize: false }
+                },
                 "nativescript-dev-webpack/platform-css-loader",
             ]),
         },

--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -85,7 +85,10 @@ function getRules() {
                     loader: "resolve-url-loader",
                     options: { silent: true },
                 },
-                "nativescript-css-loader",
+                {
+                    loader: "nativescript-css-loader",
+                    options: { minimize: false }
+                },
                 "nativescript-dev-webpack/platform-css-loader",
             ]),
         },

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -84,7 +84,10 @@ function getRules() {
                     loader: "resolve-url-loader",
                     options: { silent: true },
                 },
-                "nativescript-css-loader",
+                {
+                    loader: "nativescript-css-loader",
+                    options: { minimize: false }
+                },
                 "nativescript-dev-webpack/platform-css-loader",
             ]),
         },

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -84,7 +84,10 @@ function getRules() {
                     loader: "resolve-url-loader",
                     options: { silent: true },
                 },
-                "nativescript-css-loader",
+                {
+                    loader: "nativescript-css-loader",
+                    options: { minimize: false }
+                },
                 "nativescript-dev-webpack/platform-css-loader",
             ]),
         },


### PR DESCRIPTION
When uglify is used, it triggers the minification option of the
css-loader. The css-loader uses internally cssnano to optimize the size
of the stylesheets. Since NativeScript supports only a subset of the CSS language, many of these optimizations may be damaging for the user's css.
Such is the case with `background-position`: center, which gets
translated to `background-position`: 50%, which is currently not working
in NativeScript 3.0 (https://github.com/NativeScript/NativeScript/issues/4201).

closes #135