### PR TITLE
fix(ns-bundle): parse all '*-app' flags as tns commands

### DIFF
--- a/bin/ns-bundle
+++ b/bin/ns-bundle
@@ -12,6 +12,9 @@ if (!process.env.npm_config_argv) {
     throwError({message: "No flags provided."});
 }
 
+const escape = arg => `"${arg}"`;
+const isTnsCommand = flag => flag.endsWith("-app");
+
 const npmArgs = JSON.parse(process.env.npm_config_argv).original;
 const tnsArgs = getTnsArgs(npmArgs).map(escape);
 const flags = npmArgs.filter(a => a.startsWith("--")).map(a => a.substring(2));
@@ -23,17 +26,11 @@ function getTnsArgs(args) {
         "ns-bundle",
         "--android",
         "--ios",
-        "--build-app",
-        "--start-app",
         "--uglify",
         "--nobundle",
     ];
 
-    return args.filter(a => !other.includes(a));
-}
-
-function escape(arg) {
-    return `"${arg}"`;
+    return args.filter(a => !other.includes(a) && !isTnsCommand(a));
 }
 
 execute(options);
@@ -179,15 +176,12 @@ function getPlatform(flags) {
 }
 
 function getCommand(flags) {
-    if (flags.includes("start-app") && flags.includes("build-app")) {
-        throwError({message: "You cannot use both --start-app and --build-app flags!"});
+    const commands = flags.filter(isTnsCommand);
+    if (commands.length > 1) {
+        throwError({message: `You can't use ${commands.join(", ")} together!`});
     }
 
-    if (flags.includes("start-app")) {
-        return "run";
-    } else if (flags.includes("build-app")) {
-        return "build";
-    }
+    return commands[0].replace(/-app/, "");
 }
 
 function spawnChildProcess(command, ...args) {


### PR DESCRIPTION
Allows for using --publish-app along with --start-app, --build-app, etc.