### PR TITLE
refactor: fetch V8 versions map from url or local file

### DIFF
--- a/snapshot/android/utils.js
+++ b/snapshot/android/utils.js
@@ -4,6 +4,10 @@ const { chmodSync, createWriteStream } = require("fs");
 
 const { mkdir } = require("shelljs");
 
+const CONSTANTS = {
+    SNAPSHOT_TMP_DIR: join(os.tmpdir(), "snapshot-tools"),
+};
+
 const downloadFile = (url, destinationFilePath) =>
     new Promise((resolve, reject) => {
         const request = httpsGet(url, response => {
@@ -54,7 +58,7 @@ const getJsonFile = url =>
     });
 
 module.exports = {
+    CONSTANTS,
     downloadFile,
     getJsonFile,
 };
-


### PR DESCRIPTION
Avoid sending a https request to the `v8-versions.json` file per each build.
Instead, save the file locally and read it for official android runtime versions.