### PR TITLE
refactor: fetch V8 versions map from url or local file

### DIFF
--- a/snapshot/android/snapshot-generator.js
+++ b/snapshot/android/snapshot-generator.js
@@ -1,11 +1,11 @@
 const fs = require("fs");
-const { join, dirname } = require("path");
+const { dirname, join } = require("path");
 const os = require("os");
 const child_process = require("child_process");
 
 const shelljs = require("shelljs");
 
-const { downloadFile } = require("./utils");
+const { createDirectory, downloadFile } = require("./utils");
 
 const NDK_BUILD_SEED_PATH = join(__dirname, "snapshot-generator-tools/ndk-build");
 const BUNDLE_PREAMBLE_PATH = join(__dirname, "snapshot-generator-tools/bundle-preamble.js");
@@ -63,6 +63,7 @@ SnapshotGenerator.prototype.downloadMksnapshotTool = function(snapshotToolsPath,
         return snapshotToolsDownloads[mksnapshotToolPath];
 
     const downloadUrl = MKSNAPSHOT_TOOLS_DOWNLOAD_ROOT_URL + mksnapshotToolRelativePath;
+    createDirectory(dirname(mksnapshotToolPath));
     snapshotToolsDownloads[mksnapshotToolPath] = downloadFile(downloadUrl, mksnapshotToolPath);
     return snapshotToolsDownloads[mksnapshotToolPath];
 }

--- a/snapshot/android/utils.js
+++ b/snapshot/android/utils.js
@@ -1,15 +1,20 @@
+const { chmodSync, createWriteStream, existsSync } = require("fs");
 const { get: httpsGet } = require("https");
-const { dirname } = require("path");
-const { chmodSync, createWriteStream } = require("fs");
-
+const { tmpdir } = require("os");
+const { dirname, join } = require("path");
 const { mkdir } = require("shelljs");
+
+const CONSTANTS = {
+    SNAPSHOT_TMP_DIR: join(tmpdir(), "snapshot-tools"),
+};
+
+const createDirectory = dir => mkdir('-p', dir);
 
 const downloadFile = (url, destinationFilePath) =>
     new Promise((resolve, reject) => {
         const request = httpsGet(url, response => {
             switch (response.statusCode) {
                 case 200:
-                    mkdir("-p", dirname(destinationFilePath));
                     const file = createWriteStream(destinationFilePath);
                     file.on('error', function (error) {
                         return reject(error);
@@ -54,7 +59,8 @@ const getJsonFile = url =>
     });
 
 module.exports = {
+    CONSTANTS,
+    createDirectory,
     downloadFile,
     getJsonFile,
 };
-


### PR DESCRIPTION
Avoid sending a https request to the `v8-versions.json` file per each build.
Instead, save the file locally and read it for official android runtime versions.