### PR TITLE
refactor(templates): specify tsconfig path for @ngtools/webpack loader

### DIFF
--- a/prepublish/angular/imports.js
+++ b/prepublish/angular/imports.js
@@ -1,1 +1,3 @@
-module.exports = `const { AotPlugin } = require("@ngtools/webpack");`;
+module.exports = `const { AotPlugin } = require("@ngtools/webpack");
+
+const ngToolsWebpackOptions = { tsConfigPath: "tsconfig.aot.json" };`;

--- a/prepublish/angular/plugins.js
+++ b/prepublish/angular/plugins.js
@@ -1,10 +1,11 @@
 module.exports = `
         // Angular AOT compiler
-        new AotPlugin({
-            tsConfigPath: "tsconfig.aot.json",
-            entryModule: resolve(__dirname, "app/app.module#AppModule"),
-            typeChecking: false
-        }),
+        new AotPlugin(
+            Object.assign({
+                entryModule: resolve(__dirname, "app/app.module#AppModule"),
+                typeChecking: false
+            }, ngToolsWebpackOptions)
+        ),
 
         // Resolve .ios.css and .android.css component stylesheets, and .ios.html and .android component views
         new nsWebpack.UrlResolvePlugin({

--- a/prepublish/angular/rules.js
+++ b/prepublish/angular/rules.js
@@ -1,10 +1,13 @@
 module.exports = `
         // Compile TypeScript files with ahead-of-time compiler.
         {
-            test: /\\.ts$/,
-            loaders: [
-                "nativescript-dev-webpack/tns-aot-loader",
-                "@ngtools/webpack",
+            test: /\.ts$/,
+            use: [
+                { loader: "nativescript-dev-webpack/tns-aot-loader" },
+                {
+                    loader: "@ngtools/webpack",
+                    options: ngToolsWebpackOptions,
+                },
             ]
-        }
+        },
 `;

--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -9,6 +9,8 @@ const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 
 const { AotPlugin } = require("@ngtools/webpack");
 
+const ngToolsWebpackOptions = { tsConfigPath: "tsconfig.aot.json" };
+
 const mainSheet = `app.css`;
 
 module.exports = env => {
@@ -131,12 +133,15 @@ function getRules() {
 
         // Compile TypeScript files with ahead-of-time compiler.
         {
-            test: /\.ts$/,
-            loaders: [
-                "nativescript-dev-webpack/tns-aot-loader",
-                "@ngtools/webpack",
+            test: /.ts$/,
+            use: [
+                { loader: "nativescript-dev-webpack/tns-aot-loader" },
+                {
+                    loader: "@ngtools/webpack",
+                    options: ngToolsWebpackOptions,
+                },
             ]
-        }
+        },
 
     ];
 }
@@ -181,11 +186,12 @@ function getPlugins(platform, env) {
         }),
 
         // Angular AOT compiler
-        new AotPlugin({
-            tsConfigPath: "tsconfig.aot.json",
-            entryModule: resolve(__dirname, "app/app.module#AppModule"),
-            typeChecking: false
-        }),
+        new AotPlugin(
+            Object.assign({
+                entryModule: resolve(__dirname, "app/app.module#AppModule"),
+                typeChecking: false
+            }, ngToolsWebpackOptions)
+        ),
 
         // Resolve .ios.css and .android.css component stylesheets, and .ios.html and .android component views
         new nsWebpack.UrlResolvePlugin({


### PR DESCRIPTION
- the tsconfig path is needed when worker scripts are transpiled