### PR TITLE
refactor(update-ns-webpack): provide multiple options for updating the plugin

### DIFF
--- a/bin/update-ns-webpack
+++ b/bin/update-ns-webpack
@@ -1,27 +1,13 @@
 #!/usr/bin/env node
-const { resolve } = require("path");
 
-const { getPackageJson, getProjectDir, writePackageJson } = require("../projectHelpers");
-const { addProjectFiles, removeProjectFiles } = require("../projectFilesManager");
-const { forceUpdateProjectDeps } = require("../dependencyManager");
-const { editExistingProjectFiles } = require("../projectFilesManager");
+const update = require("../verify/update");
 
-const PROJECT_DIR = getProjectDir({ nestingLvl: 2 });
-const APP_DIR = resolve(PROJECT_DIR, "app");
-const packageJson = getPackageJson(PROJECT_DIR);
-
-console.info("Updating dev dependencies...");
-const { deps } = forceUpdateProjectDeps(packageJson);
-packageJson.devDependencies = deps;
-writePackageJson(packageJson, PROJECT_DIR);
-
-console.info("\nUpdating configuration files...");
-if (process.env.npm_config_force) {
-    removeProjectFiles(PROJECT_DIR, APP_DIR);
-    addProjectFiles(PROJECT_DIR, APP_DIR);
-} else {
-    editExistingProjectFiles(PROJECT_DIR);
+const options = {
+    pluginVersion: process.env.npm_config_plugin_version,
+    deps: process.env.npm_config_deps,
+    scripts: process.env.npm_config_scripts,
+    configs: process.env.npm_config_configs,
 }
 
-console.info("\nProject successfully updated! Don't forget to run `npm install`");
+update(options);
 

--- a/installer.js
+++ b/installer.js
@@ -32,9 +32,12 @@ function uninstall() {
 
     projectFilesManager.removeProjectFiles(PROJECT_DIR, APP_DIR);
 
-    console.log("Removing npm scripts...");
-    npmScriptsManager.removeDeprecatedNpmScripts(packageJson);
-    npmScriptsManager.removeNpmScripts(packageJson.scripts);
+    const scripts = packageJson.scripts;
+    if (scripts) {
+        console.log("Removing npm scripts...");
+        npmScriptsManager.removeDeprecatedNpmScripts(scripts);
+        npmScriptsManager.removeNpmScripts(scripts);
+    }
 
     helpers.writePackageJson(packageJson, PROJECT_DIR);
 

--- a/npmScriptsManager.js
+++ b/npmScriptsManager.js
@@ -53,8 +53,16 @@ function removePlatformScripts(scripts, nameTemplate) {
     });
 }
 
+function forceUpdateNpmScripts(scripts) {
+    removeDeprecatedNpmScripts(scripts);
+    removeNpmScripts(scripts);
+
+    addNpmScripts(scripts);
+}
+
 module.exports = {
     addNpmScripts,
     removeDeprecatedNpmScripts,
     removeNpmScripts,
+    forceUpdateNpmScripts,
 };

--- a/projectFilesManager.js
+++ b/projectFilesManager.js
@@ -59,6 +59,11 @@ function removeProjectFiles(projectDir, appDir) {
     });
 }
 
+function forceUpdateProjectFiles(projectDir, appDir) {
+    removeProjectFiles(projectDir, appDir);
+    addProjectFiles(projectDir, appDir);
+}
+
 function deleteFile(destinationPath) {
     if (fs.existsSync(destinationPath)) {
         console.info(`Deleting file: ${destinationPath}`);
@@ -189,5 +194,7 @@ function tsOrJs(projectDir, name) {
 module.exports = {
     addProjectFiles,
     removeProjectFiles,
+    forceUpdateProjectFiles,
     editExistingProjectFiles,
 };
+

--- a/verify/update.js
+++ b/verify/update.js
@@ -1,0 +1,106 @@
+const { spawn } = require("child_process");
+const { resolve: pathResolve } = require("path");
+
+const { getPackageJson, getProjectDir, writePackageJson } = require("../projectHelpers");
+const { forceUpdateProjectFiles } = require("../projectFilesManager");
+const { forceUpdateProjectDeps } = require("../dependencyManager");
+const { forceUpdateNpmScripts } = require("../npmScriptsManager");
+
+const PLUGIN_NAME = "nativescript-dev-webpack";
+const PROJECT_DIR = getProjectDir({ nestingLvl: 2 });
+
+function update({
+    deps: shouldUpdateDeps,
+    scripts: shouldUpdateScripts,
+    configs: shouldUpdateConfigs,
+    projectDir = PROJECT_DIR
+} = {}) {
+
+    const commands = [];
+
+    if (shouldUpdateDeps) {
+        commands.push(() => updateDeps(projectDir));
+    }
+
+    if (shouldUpdateScripts) {
+        commands.push(() => Promise.resolve(updateScripts(projectDir)));
+    }
+
+    if (shouldUpdateConfigs) {
+        commands.push(() => Promise.resolve(updateConfigs(projectDir)));
+    }
+
+    return commands.reduce((current, next) => current.then(next), Promise.resolve());
+}
+
+function updateScripts(projectDir) {
+    console.info("Updating npm scripts...");
+
+    const packageJson = getPackageJson(projectDir);
+    const scripts = packageJson.scripts || {};
+
+    forceUpdateNpmScripts(scripts);
+    packageJson.scripts = scripts;
+    writePackageJson(packageJson, projectDir);
+}
+
+function updateDeps(projectDir) {
+    console.info("Updating dev dependencies...");
+
+    return new Promise((resolve, reject) => {
+        const packageJson = getPackageJson(projectDir);
+        const { deps } = forceUpdateProjectDeps(packageJson);
+        packageJson.devDependencies = deps;
+        writePackageJson(packageJson, projectDir);
+
+        const command = `npm install --ignore-scripts`;
+        execute(command).then(resolve).catch(reject);
+    });
+}
+
+function updateConfigs(projectDir) {
+    console.info("Updating configuration files...");
+
+    const appDir = pathResolve(projectDir, "app");
+    forceUpdateProjectFiles(projectDir, appDir);
+}
+
+function execute(command) {
+    return new Promise((resolve, reject) => {
+        const args = command.split(" ");
+        spawnChildProcess(...args)
+            .then(resolve) 
+            .catch(throwError)
+    });
+}
+
+function spawnChildProcess(command, ...args) {
+    return new Promise((resolve, reject) => {
+        const escapedArgs = args.map(a => `"${a}"`);
+
+        const childProcess = spawn(command, escapedArgs, {
+            stdio: "inherit",
+            pwd: PROJECT_DIR,
+            shell: true,
+        });
+
+        childProcess.on("close", code => {
+            if (code === 0) {
+                resolve();
+            } else {
+                reject({
+                    code,
+                    message: `child process exited with code ${code}`,
+                });
+            }
+        });
+    });
+}
+
+function throwError(error) {
+    console.error(error.message);
+    process.exit(error.code || 1);
+}
+
+module.exports = update;
+


### PR DESCRIPTION
The bin script can be used as before, but it has some additional flags:
`npm run update-ns-webpack --deps --scripts --configs`
- update dependencies (--deps)
- update npm scripts (--scripts)
- update webpack configuration files (--configs)

PS: First, you should add the following to the package.json:

```
"scripts": {
    "update-ns-webpack": "update-ns-webpack"
}
// ...
```
