### PR TITLE
feat: enable plugin to run through {N} CLI hooks

### DIFF
--- a/lib/after-prepare.js
+++ b/lib/after-prepare.js
@@ -2,7 +2,9 @@ const snapshotGenerator = require("../snapshot/android/project-snapshot-generato
 const utils = require("./utils");
 
 module.exports = function ($mobileHelper, $projectData, hookArgs) {
-	if (utils.shouldSnapshot($mobileHelper, hookArgs.platform, hookArgs.appFilesUpdaterOptions.bundle)) {
+	const env = hookArgs.env || {};
+
+	if (env["snapshot"] && utils.shouldSnapshot($mobileHelper, hookArgs.platform, hookArgs.appFilesUpdaterOptions.bundle)) {
 		snapshotGenerator.installSnapshotArtefacts($projectData.projectDir);
 	}
 }

--- a/lib/after-prepare.js
+++ b/lib/after-prepare.js
@@ -1,0 +1,8 @@
+const snapshotGenerator = require("../snapshot/android/project-snapshot-generator");
+const utils = require("./utils");
+
+module.exports = function ($mobileHelper, $projectData, hookArgs) {
+	if (utils.shouldSnapshot($mobileHelper, hookArgs.platform, hookArgs.appFilesUpdaterOptions.bundle)) {
+		snapshotGenerator.installSnapshotArtefacts($projectData.projectDir);
+	}
+}

--- a/lib/before-prepareJS.js
+++ b/lib/before-prepareJS.js
@@ -36,12 +36,14 @@ function throwError(error) {
 }
 
 function prepareJSWebpack(config, $mobileHelper, $projectData, originalArgs, originalMethod) {
-	if (config.bundle && config.release) {
+	if (config.bundle) {
 		return new Promise(function (resolve, reject) {
 			console.log(`Running webpack for ${config.platform}...`);
 			const envFlagNames = Object.keys(config.env).concat([config.platform.toLowerCase()]);
-			if (utils.shouldSnapshot($mobileHelper, config.platform, config.bundle)) {
-				envFlagNames.push("snapshot");
+
+			const snapshotEnvIndex = envFlagNames.indexOf("snapshot");
+			if (snapshotEnvIndex !== -1 && !utils.shouldSnapshot($mobileHelper, config.platform, config.bundle)) {
+				envFlagNames.splice(snapshotEnvIndex, 1);
 			}
 
 			const args = [
@@ -69,9 +71,8 @@ module.exports = function ($mobileHelper, $projectData, hookArgs) {
 	const config = {
 		env,
 		platform,
-		release: appFilesUpdaterOptions.release,
 		bundle: appFilesUpdaterOptions.bundle
 	};
 
-	return config.release && config.bundle && prepareJSWebpack.bind(prepareJSWebpack, config, $mobileHelper, $projectData);
+	return config.bundle && prepareJSWebpack.bind(prepareJSWebpack, config, $mobileHelper, $projectData);
 }

--- a/lib/before-prepareJS.js
+++ b/lib/before-prepareJS.js
@@ -1,0 +1,77 @@
+const utils = require("./utils");
+const { spawn } = require("child_process");
+const { join } = require("path");
+let hasBeenInvoked = false;
+
+function escapeWithQuotes(arg) {
+	return `"${arg}"`;
+}
+
+function spawnChildProcess(projectDir, command, ...args) {
+	return new Promise((resolve, reject) => {
+		const escapedArgs = args.map(escapeWithQuotes)
+
+		const childProcess = spawn(command, escapedArgs, {
+			stdio: "inherit",
+			pwd: projectDir,
+			shell: true,
+		});
+
+		childProcess.on("close", code => {
+			if (code === 0) {
+				resolve();
+			} else {
+				reject({
+					code,
+					message: `child process exited with code ${code}`,
+				});
+			}
+		});
+	});
+}
+
+function throwError(error) {
+	console.error(error.message);
+	process.exit(error.code || 1);
+}
+
+function prepareJSWebpack(config, $mobileHelper, $projectData, originalArgs, originalMethod) {
+	if (config.bundle && config.release) {
+		return new Promise(function (resolve, reject) {
+			console.log(`Running webpack for ${config.platform}...`);
+			const envFlagNames = Object.keys(config.env).concat([config.platform.toLowerCase()]);
+			if (utils.shouldSnapshot($mobileHelper, config.platform, config.bundle)) {
+				envFlagNames.push("snapshot");
+			}
+
+			const args = [
+				$projectData.projectDir,
+				"node",
+				"--preserve-symlinks",
+				join($projectData.projectDir, "node_modules", "webpack", "bin", "webpack.js"),
+				"--config=webpack.config.js",
+				"--progress",
+				...envFlagNames.map(item => `--env.${item}`)
+			].filter(a => !!a);
+
+			// TODO: require webpack instead of spawning
+			spawnChildProcess(...args)
+				.then(resolve)
+				.catch(throwError);
+		});
+	}
+}
+
+module.exports = function ($mobileHelper, $projectData, hookArgs) {
+	const env = hookArgs.config.env || {};
+	const platform = hookArgs.config.platform;
+	const appFilesUpdaterOptions = hookArgs.config.appFilesUpdaterOptions;
+	const config = {
+		env,
+		platform,
+		release: appFilesUpdaterOptions.release,
+		bundle: appFilesUpdaterOptions.bundle
+	};
+
+	return config.release && config.bundle && prepareJSWebpack.bind(prepareJSWebpack, config, $mobileHelper, $projectData);
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,9 @@
+const os = require("os");
+
+function shouldSnapshot($mobileHelper, platform, bundle) {
+	const platformSupportsSnapshot = $mobileHelper.isAndroidPlatform(platform);
+	const osSupportsSnapshot = os.type() !== "Windows_NT";
+	return bundle && platformSupportsSnapshot && osSupportsSnapshot;
+}
+
+module.exports.shouldSnapshot = shouldSnapshot;

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "minimatch": "^3.0.4",
     "semver": "^5.4.1",
     "shelljs": "^0.6.0",
-    "nativescript-hook": "0.2.1"
+    "nativescript-hook": "^0.2.2"
   },
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-dev-webpack",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "main": "index",
   "description": "",
   "homepage": "http://www.telerik.com",
@@ -8,6 +8,20 @@
   "contributors": [
     "Hristo Deshev <hristo.deshev@telerik.com>"
   ],
+  "nativescript": {
+    "hooks": [
+      {
+        "type": "before-prepareJSApp",
+        "script": "lib/before-prepareJS.js",
+        "inject": true
+      },
+      {
+        "type": "after-prepare",
+        "script": "lib/after-prepare.js",
+        "inject": true
+      }
+    ]
+  },
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -28,7 +42,8 @@
   "dependencies": {
     "minimatch": "^3.0.4",
     "semver": "^5.4.1",
-    "shelljs": "^0.6.0"
+    "shelljs": "^0.6.0",
+    "nativescript-hook": "0.2.1"
   },
   "devDependencies": {}
 }

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,2 +1,7 @@
+"use strict";
+
+const hook = require("nativescript-hook")(__dirname);
+hook.postinstall();
+
 const installer = require("./installer");
 installer.install();

--- a/prepublish/common/plugins.js
+++ b/prepublish/common/plugins.js
@@ -19,14 +19,14 @@ module.exports = `
             { from: "**/*.jpg" },
             { from: "**/*.png" },
             { from: "**/*.xml" },
-        ], { ignore: ["App_Resources/**"] }),
+        ]),
 
         // Generate a bundle starter script and activate it in package.json
         new nsWebpack.GenerateBundleStarterPlugin([
             "./vendor",
             "./bundle",
         ]),
-        
+
         // Support for web workers since v3.2
         new NativeScriptWorkerPlugin(),
 

--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -178,14 +178,14 @@ function getPlugins(platform, env) {
             { from: "**/*.jpg" },
             { from: "**/*.png" },
             { from: "**/*.xml" },
-        ], { ignore: ["App_Resources/**"] }),
+        ]),
 
         // Generate a bundle starter script and activate it in package.json
         new nsWebpack.GenerateBundleStarterPlugin([
             "./vendor",
             "./bundle",
         ]),
-        
+
         // Support for web workers since v3.2
         new NativeScriptWorkerPlugin(),
 

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -162,14 +162,14 @@ function getPlugins(platform, env) {
             { from: "**/*.jpg" },
             { from: "**/*.png" },
             { from: "**/*.xml" },
-        ], { ignore: ["App_Resources/**"] }),
+        ]),
 
         // Generate a bundle starter script and activate it in package.json
         new nsWebpack.GenerateBundleStarterPlugin([
             "./vendor",
             "./bundle",
         ]),
-        
+
         // Support for web workers since v3.2
         new NativeScriptWorkerPlugin(),
 

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -171,14 +171,14 @@ function getPlugins(platform, env) {
             { from: "**/*.jpg" },
             { from: "**/*.png" },
             { from: "**/*.xml" },
-        ], { ignore: ["App_Resources/**"] }),
+        ]),
 
         // Generate a bundle starter script and activate it in package.json
         new nsWebpack.GenerateBundleStarterPlugin([
             "./vendor",
             "./bundle",
         ]),
-        
+
         // Support for web workers since v3.2
         new NativeScriptWorkerPlugin(),
 


### PR DESCRIPTION
Instead of relying on npm scripts, rely on hooks so that certain parts of the prepare chain can be overriden.
Do not skip moving `App_Resources` directory, as CLI expects it to be present in platforms and will take care of the resources inside.

Merge along with https://github.com/NativeScript/nativescript-cli/pull/3116

Ping @rosen-vladimirov @sis0k0 