### PR TITLE
refactor: update Android project path to support next runtime

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,8 @@ exports.getAppPath = platform => {
         const RESOURCES_PATH = "src/main/assets/app";
         const PROJECT_ROOT_PATH = "platforms/android";
 
-        const appPath = semver.lt(androidPackageVersion, "3.4.0") ?
+        const normalizedPlatformVersion = `${semver.major(androidPackageVersion)}.${semver.minor(androidPackageVersion)}.0`;
+        const appPath = semver.lt(normalizedPlatformVersion, "3.4.0") ?
             path.join(PROJECT_ROOT_PATH, RESOURCES_PATH) :
             path.join(PROJECT_ROOT_PATH, "app", RESOURCES_PATH);
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 const path = require("path");
 const { existsSync } = require("fs");
-const semver = require("semver");
 
-const { getPackageJson, getProjectDir, isAngular, getAndroidRuntimeVersion } = require("./projectHelpers");
+const { getPackageJson, getProjectDir, isAngular, resolveAndroidAppPath } = require("./projectHelpers");
 
 const PROJECT_DIR = getProjectDir({ nestingLvl: 2 });
 const APP_DIR = path.join(PROJECT_DIR, "app");
@@ -32,16 +31,7 @@ exports.getAppPath = platform => {
 
         return `platforms/ios/${sanitizedName}/app`;
     } else if (/android/i.test(platform)) {
-        const androidPackageVersion = getAndroidRuntimeVersion(PROJECT_DIR);
-        const RESOURCES_PATH = "src/main/assets/app";
-        const PROJECT_ROOT_PATH = "platforms/android";
-
-        const normalizedPlatformVersion = `${semver.major(androidPackageVersion)}.${semver.minor(androidPackageVersion)}.0`;
-        const appPath = semver.lt(normalizedPlatformVersion, "3.4.0") ?
-            path.join(PROJECT_ROOT_PATH, RESOURCES_PATH) :
-            path.join(PROJECT_ROOT_PATH, "app", RESOURCES_PATH);
-
-        return path.join(PROJECT_DIR, appPath);
+        return resolveAndroidAppPath(PROJECT_DIR);
     } else {
         throw new Error(`Invalid platform: ${platform}`);
     }

--- a/index.js
+++ b/index.js
@@ -1,14 +1,15 @@
 const path = require("path");
 const { existsSync } = require("fs");
+const semver = require("semver");
 
-const { getPackageJson, getProjectDir, isAngular } = require("./projectHelpers");
+const { getPackageJson, getProjectDir, isAngular, getAndroidRuntimeVersion } = require("./projectHelpers");
 
 const PROJECT_DIR = getProjectDir({ nestingLvl: 2 });
 const APP_DIR = path.join(PROJECT_DIR, "app");
 
 Object.assign(exports, require('./plugins'));
 
-if (isAngular({projectDir: PROJECT_DIR})) {
+if (isAngular({ projectDir: PROJECT_DIR })) {
     Object.assign(exports, require('./plugins/angular'));
 }
 
@@ -31,7 +32,15 @@ exports.getAppPath = platform => {
 
         return `platforms/ios/${sanitizedName}/app`;
     } else if (/android/i.test(platform)) {
-        return path.join(PROJECT_DIR, "platforms/android/src/main/assets/app");
+        const androidPackageVersion = getAndroidRuntimeVersion(PROJECT_DIR);
+        const RESOURCES_PATH = "src/main/assets/app";
+        const PROJECT_ROOT_PATH = "platforms/android";
+
+        const appPath = semver.lt(androidPackageVersion, "3.4.0") ?
+            path.join(PROJECT_ROOT_PATH, RESOURCES_PATH) :
+            path.join(PROJECT_ROOT_PATH, "app", RESOURCES_PATH);
+
+        return path.join(PROJECT_DIR, appPath);
     } else {
         throw new Error(`Invalid platform: ${platform}`);
     }

--- a/plugins/NativeScriptSnapshotPlugin.js
+++ b/plugins/NativeScriptSnapshotPlugin.js
@@ -2,6 +2,7 @@ const { resolve, join } = require("path");
 const { closeSync, openSync } = require("fs");
 
 const ProjectSnapshotGenerator = require("../snapshot/android/project-snapshot-generator");
+const { resolveAndroidAppPath } = require("../projectHelpers");
 
 exports.NativeScriptSnapshotPlugin = (function() {
     function NativeScriptSnapshotPlugin(options) {
@@ -43,8 +44,8 @@ exports.NativeScriptSnapshotPlugin = (function() {
 
         console.log(`\n Snapshotting bundle at ${inputFile}`);
 
-        const preparedAppRootPath = join(options.projectRoot, "platforms/android/src/main/assets");
-        const preprocessedInputFile = join(preparedAppRootPath, "app/_embedded_script_.js");
+        const preparedAppRootPath = resolveAndroidAppPath(this.options.projectRoot);
+        const preprocessedInputFile = join(preparedAppRootPath, "_embedded_script_.js");
 
         return ProjectSnapshotGenerator.prototype.generate.call(this, {
             inputFile,
@@ -52,7 +53,7 @@ exports.NativeScriptSnapshotPlugin = (function() {
             targetArchs: options.targetArchs,
             useLibs: options.useLibs,
             androidNdkPath: options.androidNdkPath,
-            tnsJavaClassesPath: join(preparedAppRootPath, "app/tns-java-classes.js")
+            tnsJavaClassesPath: join(preparedAppRootPath, "tns-java-classes.js")
         }).then(() => {
             // Make the original file empty
             if (inputFile !== preprocessedInputFile) {

--- a/projectHelpers.js
+++ b/projectHelpers.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const fs = require("fs");
+const semver = require("semver");
 
 const isTypeScript = ({ projectDir, packageJson } = {}) => {
     packageJson = packageJson || getPackageJson(projectDir);
@@ -63,6 +64,19 @@ const getProjectDir = ({ nestingLvl } = { nestingLvl: 0 }) => {
             .reduce(dir => path.dirname(dir), __dirname);
 };
 
+const resolveAndroidAppPath = (projectDir) => {
+    const androidPackageVersion = getAndroidRuntimeVersion(projectDir);
+    const RESOURCES_PATH = "src/main/assets/app";
+    const PROJECT_ROOT_PATH = "platforms/android";
+
+    const normalizedPlatformVersion = `${semver.major(androidPackageVersion)}.${semver.minor(androidPackageVersion)}.0`;
+    const appPath = semver.lt(normalizedPlatformVersion, "3.4.0") ?
+        path.join(PROJECT_ROOT_PATH, RESOURCES_PATH) :
+        path.join(PROJECT_ROOT_PATH, "app", RESOURCES_PATH);
+
+    return path.join(projectDir, appPath);
+};
+
 const getPackageJsonPath = projectDir => path.resolve(projectDir, "package.json");
 
 module.exports = {
@@ -72,4 +86,5 @@ module.exports = {
     getPackageJson,
     getProjectDir,
     getAndroidRuntimeVersion,
+    resolveAndroidAppPath,
 };

--- a/projectHelpers.js
+++ b/projectHelpers.js
@@ -1,24 +1,34 @@
 const path = require("path");
 const fs = require("fs");
 
-const isTypeScript = ({projectDir, packageJson} = {}) => {
+const isTypeScript = ({ projectDir, packageJson } = {}) => {
     packageJson = packageJson || getPackageJson(projectDir);
 
     return (
         packageJson.dependencies &&
         packageJson.dependencies.hasOwnProperty("typescript")
     ) || (
-        packageJson.devDependencies &&
-        packageJson.devDependencies.hasOwnProperty("typescript")
-    ) || isAngular({packageJson});
+            packageJson.devDependencies &&
+            packageJson.devDependencies.hasOwnProperty("typescript")
+        ) || isAngular({ packageJson });
 };
 
-const isAngular = ({projectDir, packageJson} = {}) => {
+const isAngular = ({ projectDir, packageJson } = {}) => {
     packageJson = packageJson || getPackageJson(projectDir);
 
     return packageJson.dependencies && Object.keys(packageJson.dependencies)
         .some(dependency => /^@angular\b/.test(dependency));
 };
+
+const getAndroidRuntimeVersion = (projectDir) => {
+    try {
+        const projectPackageJSON = getPackageJson(projectDir);
+
+        return projectPackageJSON["nativescript"]["tns-android"]["version"];
+    } catch (e) {
+        return null;
+    }
+}
 
 const getPackageJson = projectDir => {
     const packageJsonPath = getPackageJsonPath(projectDir);
@@ -29,7 +39,6 @@ const writePackageJson = (content, projectDir) => {
     const packageJsonPath = getPackageJsonPath(projectDir);
     fs.writeFileSync(packageJsonPath, JSON.stringify(content, null, 2))
 }
-
 const getProjectDir = ({ nestingLvl } = { nestingLvl: 0 }) => {
     // INIT_CWD is available since npm 5.4
     const initCwd = process.env.INIT_CWD;
@@ -62,4 +71,5 @@ module.exports = {
     writePackageJson,
     getPackageJson,
     getProjectDir,
+    getAndroidRuntimeVersion,
 };

--- a/projectHelpers.js
+++ b/projectHelpers.js
@@ -2,7 +2,6 @@ const path = require("path");
 const fs = require("fs");
 const semver = require("semver");
 
-
 const isTypeScript = ({ projectDir, packageJson } = {}) => {
     packageJson = packageJson || getPackageJson(projectDir);
 

--- a/snapshot/android/project-snapshot-generator.js
+++ b/snapshot/android/project-snapshot-generator.js
@@ -11,7 +11,7 @@ const {
     createDirectory,
     getJsonFile,
 } = require("./utils");
-const { getPackageJson } = require("../../projectHelpers");
+const { getPackageJson, getAndroidRuntimeVersion } = require("../../projectHelpers");
 
 const MIN_ANDROID_RUNTIME_VERSION = "3.0.0";
 const VALID_ANDROID_RUNTIME_TAGS = Object.freeze(["next", "rc"]);
@@ -25,10 +25,10 @@ const resolveRelativePath = (path) => {
     return null;
 };
 
-function ProjectSnapshotGenerator (options) {
+function ProjectSnapshotGenerator(options) {
     this.options = options = options || {};
 
-    options.projectRoot = resolveRelativePath(options.projectRoot) ||  process.cwd();
+    options.projectRoot = resolveRelativePath(options.projectRoot) || process.cwd();
 
     console.log("Project root: " + options.projectRoot);
     console.log("Snapshots build directory: " + this.getBuildPath());
@@ -37,15 +37,15 @@ function ProjectSnapshotGenerator (options) {
 }
 module.exports = ProjectSnapshotGenerator;
 
-ProjectSnapshotGenerator.calculateBuildPath = function(projectRoot) {
+ProjectSnapshotGenerator.calculateBuildPath = function (projectRoot) {
     return join(projectRoot, "platforms/android/snapshot-build/build");
 }
 
-ProjectSnapshotGenerator.prototype.getBuildPath = function() {
+ProjectSnapshotGenerator.prototype.getBuildPath = function () {
     return ProjectSnapshotGenerator.calculateBuildPath(this.options.projectRoot);
 }
 
-ProjectSnapshotGenerator.cleanSnapshotArtefacts = function(projectRoot) {
+ProjectSnapshotGenerator.cleanSnapshotArtefacts = function (projectRoot) {
     const platformPath = join(projectRoot, "platforms/android");
 
     // Remove blob files from prepared folder
@@ -55,7 +55,7 @@ ProjectSnapshotGenerator.cleanSnapshotArtefacts = function(projectRoot) {
     shelljs.rm("-rf", join(platformPath, "configurations/", SnapshotGenerator.SNAPSHOT_PACKAGE_NANE));
 }
 
-ProjectSnapshotGenerator.installSnapshotArtefacts = function(projectRoot) {
+ProjectSnapshotGenerator.installSnapshotArtefacts = function (projectRoot) {
     const buildPath = ProjectSnapshotGenerator.calculateBuildPath(projectRoot);
     const platformPath = join(projectRoot, "platforms/android");
     const assetsPath = join(platformPath, "src/main/assets");
@@ -139,16 +139,16 @@ const getV8VersionsMap = runtimeVersion =>
         }
     });
 
-ProjectSnapshotGenerator.prototype.getV8Version = function(generationOptions) {
+ProjectSnapshotGenerator.prototype.getV8Version = function (generationOptions) {
     return new Promise((resolve, reject) => {
         const maybeV8Version = generationOptions.v8Version;
         if (maybeV8Version) {
             return resolve(maybeV8Version);
         }
 
-        const runtimeVersion = this.getAndroidRuntimeVersion();
+        const runtimeVersion = this.getAndroidRuntimeVersion(this.options.projectRoot);
         getV8VersionsMap(runtimeVersion)
-            .then(({ versionsMap, latest}) => {
+            .then(({ versionsMap, latest }) => {
                 const v8Version = findV8Version(runtimeVersion, versionsMap);
 
                 if (!v8Version && !latest) {
@@ -165,8 +165,8 @@ ProjectSnapshotGenerator.prototype.getV8Version = function(generationOptions) {
     });
 }
 
-ProjectSnapshotGenerator.prototype.validateAndroidRuntimeVersion = function() {
-    const currentRuntimeVersion = this.getAndroidRuntimeVersion();
+ProjectSnapshotGenerator.prototype.validateAndroidRuntimeVersion = function () {
+    const currentRuntimeVersion = getAndroidRuntimeVersion(this.options.projectRoot);
 
     if (!currentRuntimeVersion ||
         !existsSync(join(this.options.projectRoot, "platforms/android"))) {
@@ -182,17 +182,7 @@ ProjectSnapshotGenerator.prototype.validateAndroidRuntimeVersion = function() {
     }
 }
 
-ProjectSnapshotGenerator.prototype.getAndroidRuntimeVersion = function() {
-    try {
-        const projectPackageJSON = getPackageJson(this.options.projectRoot);
-
-        return projectPackageJSON["nativescript"]["tns-android"]["version"];
-    } catch(e) {
-        return null;
-    }
-}
-
-ProjectSnapshotGenerator.prototype.generateTnsJavaClassesFile = function(generationOptions) {
+ProjectSnapshotGenerator.prototype.generateTnsJavaClassesFile = function (generationOptions) {
     const tnsJavaClassesGenerator = new TnsJavaClassesGenerator();
     return tnsJavaClassesGenerator.generate({
         projectRoot: this.options.projectRoot,
@@ -201,7 +191,7 @@ ProjectSnapshotGenerator.prototype.generateTnsJavaClassesFile = function(generat
     });
 }
 
-ProjectSnapshotGenerator.prototype.generate = function(generationOptions) {
+ProjectSnapshotGenerator.prototype.generate = function (generationOptions) {
     generationOptions = generationOptions || {};
 
     console.log("Running snapshot generation with the following arguments: ");

--- a/snapshot/android/snapshot-generator.js
+++ b/snapshot/android/snapshot-generator.js
@@ -81,7 +81,6 @@ SnapshotGenerator.prototype.convertToAndroidArchName = function(archName) {
 SnapshotGenerator.prototype.runMksnapshotTool = function(snapshotToolsPath, inputFile, v8Version, targetArchs, buildCSource) {
     // Cleans the snapshot build folder
     shelljs.rm("-rf", join(this.buildPath, "snapshots"));
-    console.log("000 v8 version" + v8Version);
 
     const mksnapshotStdErrPath = join(this.buildPath, "mksnapshot-stderr.txt");
 

--- a/snapshot/android/snapshot-generator.js
+++ b/snapshot/android/snapshot-generator.js
@@ -81,6 +81,7 @@ SnapshotGenerator.prototype.convertToAndroidArchName = function(archName) {
 SnapshotGenerator.prototype.runMksnapshotTool = function(snapshotToolsPath, inputFile, v8Version, targetArchs, buildCSource) {
     // Cleans the snapshot build folder
     shelljs.rm("-rf", join(this.buildPath, "snapshots"));
+    console.log("000 v8 version" + v8Version);
 
     const mksnapshotStdErrPath = join(this.buildPath, "mksnapshot-stderr.txt");
 


### PR DESCRIPTION
_problem_
nativescript-dev-webpack is not compatible with new android studio project template

_solution_
need to change bundle output path, depending on the android template version