### PR TITLE
fix(ns-bundle): support for Node.js 9

### DIFF
--- a/bin/ns-bundle
+++ b/bin/ns-bundle
@@ -53,8 +53,8 @@ execute(options);
 
 function execute(options) {
     const platform = options.platform;
-    let commands = [ 
-        () => runTns("prepare", platform) 
+    let commands = [
+        () => runTns("prepare", platform)
     ];
 
     if (options.bundle) {
@@ -70,7 +70,7 @@ function execute(options) {
     if (shouldSnapshot(platform, options.env)) {
         commands.push(() => installSnapshotArtefacts());
     }
-    
+
     // If "build-app" or "start-app" is specified,
     // the respective command should be run last.
     if (options.command) {
@@ -123,8 +123,8 @@ function gradlewClean() {
 function getTnsVersion() {
     return new Promise((resolve, reject) => {
         const childProcess = spawn("tns", ["--version"], { shell: true });
-
-        childProcess.stdout.on("data", version => resolve(version.toString()));
+        let stdoutData = "";
+        childProcess.stdout.on("data", data => stdoutData += data);
 
         childProcess.on("close", code => {
             if (code) {
@@ -132,6 +132,11 @@ function getTnsVersion() {
                     code,
                     message: `child process exited with code ${code}`,
                 });
+            } else {
+                const versionRegex = /^(?:\d+\.){2}\d+.*?$/m;
+                const matches = stdoutData.toString().match(versionRegex);
+                const version = matches && matches[0] && matches[0].trim();
+                resolve(version);
             }
         });
     });


### PR DESCRIPTION
When you have Node.js 9 installed, CLI prints a warning that support for this version is not verified. Our webpack plugin tries to get the version, but it receives the warning and decides the version is incorrect. So all scripts fail.
In order to resolve the issue, get all data send to the stdout of the spawned `tns --version` process and parse it.