### PR TITLE
refactor: loadChildren to work with ~/path and ./path both relative to app/

### DIFF
--- a/demo/AngularApp/app/ninjas/ninjas.component.ts
+++ b/demo/AngularApp/app/ninjas/ninjas.component.ts
@@ -6,13 +6,13 @@ import { Component } from "@angular/core";
             <Label text="Ninjas!" class="h1 text-center"></Label>
 
             <ListView [items]="ninjas" class="list-group">
-                <ng-template let-ninja="item">
+                <ng-template let-ninja="item" let-index="index">
                         <Label
                             class="list-group-item"
                             color="white"
                             [backgroundColor]="ninja.color"
                             [text]="ninja.name"
-                            [nsRouterLink]="['details', ninja.name]"></Label>
+                            [nsRouterLink]="['details' + (index % 2 + 1) , ninja.name]"></Label>
                 </ng-template>
             </ListView>
 

--- a/demo/AngularApp/app/ninjas/ninjas.routes.ts
+++ b/demo/AngularApp/app/ninjas/ninjas.routes.ts
@@ -6,7 +6,11 @@ export const routes = [
         component: NinjasComponent
     },
     {
-        path: "details",
+        path: "details1",
+        loadChildren: "./ninjas/details/ninja.module#NinjaModule",
+    },
+    {
+        path: "details2",
         loadChildren: "~/ninjas/details/ninja.module#NinjaModule",
     },
 ];


### PR DESCRIPTION
It turns out the ./path for loadChildren have never worked as relative to the routes module,
and was always expected to be relative to app/ in non-webpack builds. Modifying the lazy loaded
ninjas to feature both ./ and ~/ paths relative to the app.