### PR TITLE
fix(snapshot): use autoclose option on writestream

### DIFF
--- a/snapshot/android/utils.js
+++ b/snapshot/android/utils.js
@@ -15,12 +15,11 @@ const downloadFile = (url, destinationFilePath) =>
         const request = httpsGet(url, response => {
             switch (response.statusCode) {
                 case 200:
-                    const file = createWriteStream(destinationFilePath);
+                    const file = createWriteStream(destinationFilePath, {autoClose: true});
                     file.on('error', function (error) {
                         return reject(error);
                     });
                     file.on("finish", function() {
-                        file.close();
                         chmodSync(destinationFilePath, 0755);
                         return resolve(destinationFilePath);
                     });


### PR DESCRIPTION
_problem_
Node 9.x WriteFileStream API is changed. [Read more here](https://github.com/nodejs/node/pull/15407).

_solution_
use new API that should be backward compatible.

fixes: https://github.com/NativeScript/nativescript-dev-webpack/issues/344