### PR TITLE
fix(compiler): reject promise with real error

### DIFF
--- a/lib/before-prepareJS.js
+++ b/lib/before-prepareJS.js
@@ -10,6 +10,6 @@ module.exports = function ($mobileHelper, $projectData, hookArgs) {
 		bundle: appFilesUpdaterOptions.bundle,
 		watch: false // TODO: Read from CLI options...
 	};
-	const result = config.bundle && runWebpackCompiler.bind(runWebpackCompiler, config, $mobileHelper, $projectData);
+	const result = config.bundle && runWebpackCompiler.bind(runWebpackCompiler, config, $mobileHelper, $projectData, hookArgs);
 	return result;
 }

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -13,9 +13,13 @@ exports.getWebpackProcess = function getWebpackProcess() {
     return webpackProcess;
 }
 
-exports.runWebpackCompiler = function runWebpackCompiler(config, $mobileHelper, $projectData, originalArgs, originalMethod) {
+exports.runWebpackCompiler = function runWebpackCompiler(config, $mobileHelper, $projectData, hookArgs, originalArgs, originalMethod) {
     if (config.bundle) {
         return new Promise(function (resolveBase, rejectBase) {
+            if (hookArgs && hookArgs.config && hookArgs.config.changesInfo) {
+                hookArgs.config.changesInfo.nativeChanged = true;
+            }
+
             let isResolved = false;
             function resolve() {
                 if (isResolved) return;

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -25,13 +25,13 @@ exports.runWebpackCompiler = function runWebpackCompiler(config, $mobileHelper, 
                 }
                 resolveBase();
             }
-            function reject() {
+            function reject(error) {
                 if (isResolved) return;
                 isResolved = true;
                 if (childProcess) {
                     childProcess.removeListener("message", resolveOnWebpackCompilationComplete);
                 }
-                rejectBase();
+                rejectBase(error);
             }
 
             console.log(`Running webpack for ${config.platform}...`);
@@ -93,10 +93,9 @@ exports.runWebpackCompiler = function runWebpackCompiler(config, $mobileHelper, 
                 if (code === 0) {
                     resolve();
                 } else {
-                    reject({
-                        code,
-                        message: `child process exited with code ${code}`,
-                    });
+                    const error = new Error(`Executing webpack failed with exit code ${code}.`);
+                    error.code = code;
+                    reject(error);
                 }
             });
         });


### PR DESCRIPTION
When the webpack compiler fails, the error is not used in the rejection, so the promise is always rejected with `undefined`.
Fix this by respecting the error. Construct real error object as well.

Force rebuild of application when webpack is used  …
In case we want to use webpack, force the build by setting nativeChanged property of changesInfo to true.
This is TEMP solution until we have a better one.

Fixes https://github.com/NativeScript/nativescript-dev-webpack/issues/340