### PR TITLE
refactor: Show watch state messages only when webpack is watching

### DIFF
--- a/plugins/WatchStateLoggerPlugin.ts
+++ b/plugins/WatchStateLoggerPlugin.ts
@@ -9,15 +9,22 @@ export enum messages {
  * So the {N} CLI can get some idea when compilation completes.
  */
 export class WatchStateLoggerPlugin {
+    isRunningWatching: boolean;
     apply(compiler) {
+        const plugin = this;
         compiler.plugin("watch-run", function(compiler, callback) {
-            console.log(messages.changeDetected);
+            plugin.isRunningWatching = true;
+            if (plugin.isRunningWatching) {
+                console.log(messages.changeDetected);
+            }
             process.send && process.send(messages.changeDetected, error => null);
             callback();
         });
         compiler.plugin("after-emit", function(compilation, callback) {
             callback();
-            console.log(messages.compilationComplete);
+            if (plugin.isRunningWatching) {
+                console.log(messages.compilationComplete);
+            }
             process.send && process.send(messages.compilationComplete, error => null);
         });
     }


### PR DESCRIPTION
When run with `webpack --watch` the WatchStateLoggerPlugin
will print console messages with the watcher state.
When run with `webpack` (no --watch) the WatchStateLoggerPlugin
will be silent in the console, but still notify via IPC.