### PR TITLE
refactor: Add options to the @ngtools/webpack loaders for workers support

### DIFF
--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -68,7 +68,10 @@ module.exports = env => {
                 { test: /\.scss$/, exclude: /\/app\.scss$/, use: ["raw-loader", "resolve-url-loader", "sass-loader"] },
 
                 // Compile TypeScript files with ahead-of-time compiler.
-                { test: /.ts$/, use: ["nativescript-dev-webpack/moduleid-compat-loader", "@ngtools/webpack"] },
+                { test: /.ts$/, use: [
+                    "nativescript-dev-webpack/moduleid-compat-loader",
+                    { loader: "@ngtools/webpack", options: ngToolsWebpackOptions },
+                ]},
             ],
         },
         plugins: [


### PR DESCRIPTION
Loading the .ts files for WebWorkers using the @ngtools/webpack requires
at least the tsConfigPath to be provided to the loader as options.