### PR TITLE
refactor(webworkers): Add empty compilerOptions in tsconfig.aot.json

### DIFF
--- a/templates/tsconfig.aot.json
+++ b/templates/tsconfig.aot.json
@@ -1,5 +1,7 @@
 {
   "extends": "./tsconfig",
+  "compilerOptions": {
+  },
   "angularCompilerOptions": {
     "skipMetadataEmit": true,
     "genDir": "./"


### PR DESCRIPTION
This workarounds a bug in the integration of @ngtools/webpack and TypeScript,
creating TypeScript CompilerHost with undefined compilerOptions.
To reproduce run the webworker demo with `tns run android --bundle --env.aot`.