### PR TITLE
refactor: remove tsconfig.aot.json file

### DIFF
--- a/projectFilesManager.js
+++ b/projectFilesManager.js
@@ -85,7 +85,6 @@ function getProjectTemplates(projectDir) {
 
     if (isAngular({projectDir})) {
         templates["webpack.angular.js"] = "webpack.config.js";
-        templates["tsconfig.aot.json"] = "tsconfig.aot.json";
     } else if (isTypeScript({projectDir})) {
         templates["webpack.typescript.js"] = "webpack.config.js";
     } else {

--- a/templates/tsconfig.aot.json
+++ b/templates/tsconfig.aot.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig",
-  "angularCompilerOptions": {
-    "skipMetadataEmit": true,
-    "genDir": "./"
-  }
-}

--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -15,7 +15,7 @@ module.exports = env => {
     }
     const platforms = ["ios", "android"];
     const { snapshot, uglify, report, aot } = env;
-    const ngToolsWebpackOptions = { tsConfigPath: aot ? "tsconfig.aot.json" : "tsconfig.json"};
+    const ngToolsWebpackOptions = { tsConfigPath: "tsconfig.json" };
 
     const config = {
         context: resolve("./app"),


### PR DESCRIPTION
The angular compiler options inside tsconfig.aot.json are not needed for webpack compilation.