### PR TITLE
fix(css): disable minification when using uglify

### DIFF
--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -60,8 +60,23 @@ module.exports = env => {
                 { test: /\.html$|\.xml$/, use: "raw-loader" },
 
                 // tns-core-modules reads the app.css and its imports using css-loader
-                { test: /[\/|\\]app\.css$/, use: "css-loader?url=false" },
-                { test: /[\/|\\]app\.scss$/, use: ["css-loader?url=false", "sass-loader"] },
+                {
+                    test: /[\/|\\]app\.css$/,
+                    use: {
+                        loader: "css-loader",
+                        options: { minimize: false, url: false },
+                    }
+                },
+                {
+                    test: /[\/|\\]app\.scss$/,
+                    use: [
+                        {
+                            loader: "css-loader",
+                            options: { minimize: false, url: false },
+                        },
+                        "sass-loader"
+                    ]
+                },
 
                 // Angular components reference css files and their imports using raw-loader
                 { test: /\.css$/, exclude: /[\/|\\]app\.css$/, use: "raw-loader" },

--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -70,10 +70,7 @@ module.exports = env => {
                 {
                     test: /[\/|\\]app\.scss$/,
                     use: [
-                        {
-                            loader: "css-loader",
-                            options: { minimize: false, url: false },
-                        },
+                        { loader: "css-loader", options: { minimize: false, url: false } },
                         "sass-loader"
                     ]
                 },

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -57,8 +57,24 @@ module.exports = env => {
             rules: [
                 { test: /\.(html|xml)$/, use: "raw-loader" },
 
-                { test: /\.css$/, use: "css-loader?url=false" },
-                { test: /\.scss$/, use: ["css-loader?url=false", "sass-loader"] },
+                {
+                    test: /\.css$/,
+                    use: {
+                        loader: "css-loader",
+                        options: { minimize: false, url: false },
+                    }
+                },
+
+                {
+                    test: /\.scss$/,
+                    use: [
+                        {
+                            loader: "css-loader",
+                            options: { minimize: false, url: false },
+                        },
+                        "sass-loader"
+                    ]
+                }
             ]
         },
         plugins: [

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -59,19 +59,13 @@ module.exports = env => {
 
                 {
                     test: /\.css$/,
-                    use: {
-                        loader: "css-loader",
-                        options: { minimize: false, url: false },
-                    }
+                    use: { loader: "css-loader", options: { minimize: false, url: false } }
                 },
 
                 {
                     test: /\.scss$/,
                     use: [
-                        {
-                            loader: "css-loader",
-                            options: { minimize: false, url: false },
-                        },
+                        { loader: "css-loader", options: { minimize: false, url: false } },
                         "sass-loader"
                     ]
                 }

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -59,19 +59,13 @@ module.exports = env => {
 
                 {
                     test: /\.css$/,
-                    use: {
-                        loader: "css-loader",
-                        options: { minimize: false, url: false },
-                    }
+                    use: { loader: "css-loader", options: { minimize: false, url: false } }
                 },
 
                 {
                     test: /\.scss$/,
                     use: [
-                        {
-                            loader: "css-loader",
-                            options: { minimize: false, url: false },
-                        },
+                        { loader: "css-loader", options: { minimize: false, url: false } },
                         "sass-loader"
                     ]
                 },

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -57,8 +57,24 @@ module.exports = env => {
             rules: [
                 { test: /\.(html|xml)$/, use: "raw-loader" },
 
-                { test: /\.css$/, use: "css-loader?url=false" },
-                { test: /\.scss$/, use: ["css-loader?url=false", "sass-loader"] },
+                {
+                    test: /\.css$/,
+                    use: {
+                        loader: "css-loader",
+                        options: { minimize: false, url: false },
+                    }
+                },
+
+                {
+                    test: /\.scss$/,
+                    use: [
+                        {
+                            loader: "css-loader",
+                            options: { minimize: false, url: false },
+                        },
+                        "sass-loader"
+                    ]
+                },
 
                 { test: /\.ts$/, use: "awesome-typescript-loader" }
             ]


### PR DESCRIPTION
When uglify is used, it triggers the minification option of the
css-loader. The css-loader uses internally cssnano to optimize the size
of the stylesheets. Since NativeScript supports only a subset of the CSS language, many of these optimizations may be damaging for the user's css.

related to #154, #135
fixes #377