### PR TITLE
fix: respect windows paths in /app.css regex

### DIFF
--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -60,12 +60,12 @@ module.exports = env => {
                 { test: /\.html$|\.xml$/, use: "raw-loader" },
 
                 // tns-core-modules reads the app.css and its imports using css-loader
-                { test: /\/app\.css$/, use: "css-loader?url=false" },
-                { test: /\/app\.scss$/, use: ["css-loader?url=false", "sass-loader"] },
+                { test: /[\/|\\]app\.css$/, use: "css-loader?url=false" },
+                { test: /[\/|\\]app\.scss$/, use: ["css-loader?url=false", "sass-loader"] },
 
                 // Angular components reference css files and their imports using raw-loader
-                { test: /\.css$/, exclude: /\/app\.css$/, use: "raw-loader" },
-                { test: /\.scss$/, exclude: /\/app\.scss$/, use: ["raw-loader", "resolve-url-loader", "sass-loader"] },
+                { test: /\.css$/, exclude: /[\/|\\]app\.css$/, use: "raw-loader" },
+                { test: /\.scss$/, exclude: /[\/|\\]app\.scss$/, use: ["raw-loader", "resolve-url-loader", "sass-loader"] },
 
                 // Compile TypeScript files with ahead-of-time compiler.
                 { test: /.ts$/, use: [

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -13,7 +13,6 @@ module.exports = env => {
         throw new Error("You need to provide a target platform!");
     }
     const platforms = ["ios", "android"];
-    const mainSheet = "app.css";
     const { snapshot, uglify, report } = env;
 
     const config = {


### PR DESCRIPTION
Windows uses backslashes for paths. For app.css the path will be something like:
```
\\...\\projectName\\app\\app.css"
```
compared to *nix systems where the file path will be:
```
/.../projectName/app/app.css"
```

fixes #378 