### PR TITLE
fix: support aot on windows

### DIFF
--- a/plugins/NativeScriptAngularCompilerPlugin.ts
+++ b/plugins/NativeScriptAngularCompilerPlugin.ts
@@ -57,6 +57,7 @@ export class NativeScriptAngularCompilerPlugin extends AngularCompilerPlugin {
                 } catch(e) {
                 }
                 resolved = resolved || resourceNameToFileName.call(this, file, relativeTo);
+                resolved = resolved && resolved.replace(/\\/g, "/");
                 return resolved;
             };
         }


### PR DESCRIPTION
The compile host seems to use forward instead of backward slashes on windows.
 
fixes #376 