### PR TITLE
fix(uglify): prevent SideDrawer transition class names from being renamed

### DIFF
--- a/mangle-excludes.js
+++ b/mangle-excludes.js
@@ -130,5 +130,12 @@ module.exports = [
     "UIViewControllerImpl",
     "UIWebViewDelegateImpl",
     "Window",
+
+    // Sidedrawer transitions
+    // Should be removed after {N} 4.0 is released
+    // See: https://github.com/telerik/nativescript-ui-feedback/issues/477#issuecomment-360772046
+    "PushTransition",
+    "FadeTransition",
+    "SlideInOnTopTransition",
 ];
 


### PR DESCRIPTION
This should fix the issue:
```
JS: Warning: 't' is not supported when 'showOverNavigation' is set to 'true'.
```
Should be reverted after 4.0 release. See: https://github.com/telerik/nativescript-ui-feedback/issues/477#issuecomment-360772046

fixes #258