### PR TITLE
fix(snapshot): use request module for http requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "minimatch": "3.0.4",
     "nativescript-hook": "0.2.2",
+    "proxy-lib": "0.4.0",
     "request": "2.83.0",
     "schema-utils": "0.4.3",
     "semver": "5.4.1",

--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
     "generate-android-snapshot": "./bin/generate-android-snapshot"
   },
   "dependencies": {
-    "minimatch": "^3.0.4",
+    "minimatch": "3.0.4",
     "nativescript-hook": "0.2.2",
-    "request": "^2.83.0",
-    "schema-utils": "^0.4.3",
-    "semver": "^5.4.1",
-    "shelljs": "^0.6.0"
+    "request": "2.83.0",
+    "schema-utils": "0.4.3",
+    "semver": "5.4.1",
+    "shelljs": "0.6.0"
   },
   "devDependencies": {
     "@ngtools/webpack": "~1.9.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "minimatch": "^3.0.4",
     "nativescript-hook": "0.2.2",
+    "request": "^2.83.0",
     "schema-utils": "^0.4.3",
     "semver": "^5.4.1",
     "shelljs": "^0.6.0"

--- a/snapshot/android/utils.js
+++ b/snapshot/android/utils.js
@@ -32,11 +32,11 @@ const getJsonFile = url =>
             .then(options =>
                 get(options, (error, response, body) => {
                     if (error) {
-                        reject(error);
+                        return reject(error);
                     }
 
                     if (!response || response.statusCode !== 200) {
-                        reject(`Couldn't fetch ${url}! Response:\n${response}`);
+                        return reject(`Couldn't fetch ${url}! Response:\n${response}`);
                     }
 
                     try {

--- a/snapshot/android/utils.js
+++ b/snapshot/android/utils.js
@@ -29,9 +29,8 @@ const getJsonFile = url =>
                 reject(error);
             }
 
-            const { statusCode } = response;
-            if (statusCode !== 200) {
-                reject(`Couldn't fetch ${url}! Response status code: ${statusCode}`)
+            if (!response || response.statusCode !== 200) {
+                reject(`Couldn't fetch ${url}! Response:\n${response}`);
             }
 
             try {


### PR DESCRIPTION
Use 'request' node package for https requests and 'proxy-lib' for getting configured proxy settings (see: https://github.com/NativeScript/nativescript-cli/blob/master/docs/man_pages/general/proxy-set.md).

fixes #389