### PR TITLE
feat(livesync): enable webpack with watch

### DIFF
--- a/lib/before-prepareJS.js
+++ b/lib/before-prepareJS.js
@@ -7,8 +7,7 @@ module.exports = function ($mobileHelper, $projectData, hookArgs) {
 	const config = {
 		env,
 		platform,
-		bundle: appFilesUpdaterOptions.bundle,
-		watch: false
+		bundle: appFilesUpdaterOptions.bundle
 	};
 	const result = config.bundle && runWebpackCompiler.bind(runWebpackCompiler, config, $mobileHelper, $projectData, hookArgs);
 	return result;

--- a/lib/before-prepareJS.js
+++ b/lib/before-prepareJS.js
@@ -8,7 +8,7 @@ module.exports = function ($mobileHelper, $projectData, hookArgs) {
 		env,
 		platform,
 		bundle: appFilesUpdaterOptions.bundle,
-		watch: false // TODO: Read from CLI options...
+		watch: false
 	};
 	const result = config.bundle && runWebpackCompiler.bind(runWebpackCompiler, config, $mobileHelper, $projectData, hookArgs);
 	return result;

--- a/lib/before-watch.js
+++ b/lib/before-watch.js
@@ -5,7 +5,7 @@ module.exports = function ($mobileHelper, $projectData, hookArgs) {
 		const appFilesUpdaterOptions = hookArgs.config.appFilesUpdaterOptions;
 		if (appFilesUpdaterOptions.bundle) {
 			const platforms = hookArgs.config.platforms;
-			platforms.forEach(platform => {
+			return Promise.all(platforms.map(platform => {
 				const env = hookArgs.config.env || {};
 				const config = {
 					env,
@@ -14,8 +14,8 @@ module.exports = function ($mobileHelper, $projectData, hookArgs) {
 					watch: true
 				};
 
-				runWebpackCompiler(config, $mobileHelper, $projectData, hookArgs);
-			});
+				return runWebpackCompiler(config, $mobileHelper, $projectData, hookArgs);
+			}));
 		}
 	}
 }

--- a/lib/before-watch.js
+++ b/lib/before-watch.js
@@ -1,0 +1,21 @@
+const { runWebpackCompiler } = require("./compiler");
+
+module.exports = function ($mobileHelper, $projectData, hookArgs) {
+	if (hookArgs.config) {
+		const appFilesUpdaterOptions = hookArgs.config.appFilesUpdaterOptions;
+		if (appFilesUpdaterOptions.bundle) {
+			const platforms = hookArgs.config.platforms;
+			platforms.forEach(platform => {
+				const env = hookArgs.config.env || {};
+				const config = {
+					env,
+					platform,
+					bundle: appFilesUpdaterOptions.bundle,
+					watch: true
+				};
+
+				runWebpackCompiler(config, $mobileHelper, $projectData, hookArgs);
+			});
+		}
+	}
+}

--- a/lib/before-watchPatterns.js
+++ b/lib/before-watchPatterns.js
@@ -1,0 +1,20 @@
+module.exports = function (hookArgs) {
+	if (hookArgs.liveSyncData && hookArgs.liveSyncData.bundle) {
+		const appDirectoryLocation = "app"; // Might need to get this from config file in the future
+		const appResourcesDirectoryLocation = "app/App_Resources"; // Might need to get this from config file in the future
+		return (args, originalMethod) => {
+			return originalMethod().then(originalPatterns => {
+				const appDirectoryLocationIndex = originalPatterns.indexOf(appDirectoryLocation);
+				if (appDirectoryLocationIndex !== -1) {
+					originalPatterns.splice(appDirectoryLocationIndex, 1);
+				}
+
+				if (originalPatterns.indexOf(appResourcesDirectoryLocation) === -1) {
+					originalPatterns.push(appResourcesDirectoryLocation);
+				}
+
+				return originalPatterns;
+			});
+		};
+	}
+}

--- a/lib/before-watchPatterns.js
+++ b/lib/before-watchPatterns.js
@@ -1,16 +1,12 @@
+const { AppDirectoryLocation } = require("./constants");
+
 module.exports = function (hookArgs) {
 	if (hookArgs.liveSyncData && hookArgs.liveSyncData.bundle) {
-		const appDirectoryLocation = "app"; // Might need to get this from config file in the future
-		const appResourcesDirectoryLocation = "app/App_Resources"; // Might need to get this from config file in the future
 		return (args, originalMethod) => {
 			return originalMethod().then(originalPatterns => {
-				const appDirectoryLocationIndex = originalPatterns.indexOf(appDirectoryLocation);
+				const appDirectoryLocationIndex = originalPatterns.indexOf(AppDirectoryLocation);
 				if (appDirectoryLocationIndex !== -1) {
 					originalPatterns.splice(appDirectoryLocationIndex, 1);
-				}
-
-				if (originalPatterns.indexOf(appResourcesDirectoryLocation) === -1) {
-					originalPatterns.push(appResourcesDirectoryLocation);
 				}
 
 				return originalPatterns;

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -4,6 +4,7 @@ const { join, resolve: pathResolve } = require("path");
 const { existsSync } = require("fs");
 const readline = require("readline");
 const { messages } = require("../plugins/WatchStateLoggerPlugin");
+const ProjectSnapshotGenerator = require("../snapshot/android/project-snapshot-generator");
 
 let hasBeenInvoked = false;
 
@@ -16,6 +17,10 @@ exports.getWebpackProcess = function getWebpackProcess() {
 exports.runWebpackCompiler = function runWebpackCompiler(config, $mobileHelper, $projectData, hookArgs, originalArgs, originalMethod) {
     if (config.bundle) {
         return new Promise(function (resolveBase, rejectBase) {
+            if (webpackProcess) {
+                return resolveBase();
+            }
+
             if (hookArgs && hookArgs.config && hookArgs.config.changesInfo) {
                 hookArgs.config.changesInfo.nativeChanged = true;
             }
@@ -24,17 +29,11 @@ exports.runWebpackCompiler = function runWebpackCompiler(config, $mobileHelper, 
             function resolve() {
                 if (isResolved) return;
                 isResolved = true;
-                if (childProcess) {
-                    childProcess.removeListener("message", resolveOnWebpackCompilationComplete);
-                }
                 resolveBase();
             }
             function reject(error) {
                 if (isResolved) return;
                 isResolved = true;
-                if (childProcess) {
-                    childProcess.removeListener("message", resolveOnWebpackCompilationComplete);
-                }
                 rejectBase(error);
             }
 
@@ -75,10 +74,24 @@ exports.runWebpackCompiler = function runWebpackCompiler(config, $mobileHelper, 
                 cwd: $projectData.projectDir
             });
 
+            let isFirstWebpackWatchCompilation = true;
             function resolveOnWebpackCompilationComplete(message) {
                 if (message === messages.compilationComplete) {
-                    console.log("Initial webpack build done!");
+                    console.log("Webpack build done!");
                     resolve();
+                }
+
+                if (message.emittedFiles) {
+                    if (isFirstWebpackWatchCompilation) {
+                        isFirstWebpackWatchCompilation = false;
+                        return;
+                    }
+
+                    if (hookArgs.filesToSync && hookArgs.startSyncFilesTimeout) {
+                        // TODO: Might need to get the "app" constant from config file in the future
+                        hookArgs.filesToSync.push(...message.emittedFiles.map(emittedFile => join("app", emittedFile)));
+                        hookArgs.startSyncFilesTimeout();
+                    }
                 }
             }
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -21,10 +21,6 @@ exports.runWebpackCompiler = function runWebpackCompiler(config, $mobileHelper, 
                 return resolveBase();
             }
 
-            if (hookArgs && hookArgs.config && hookArgs.config.changesInfo) {
-                hookArgs.config.changesInfo.nativeChanged = true;
-            }
-
             let isResolved = false;
             function resolve() {
                 if (isResolved) return;

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -4,7 +4,7 @@ const { join, resolve: pathResolve } = require("path");
 const { existsSync } = require("fs");
 const readline = require("readline");
 const { messages } = require("../plugins/WatchStateLoggerPlugin");
-const ProjectSnapshotGenerator = require("../snapshot/android/project-snapshot-generator");
+const { AppDirectoryLocation } = require("./constants");
 
 let hasBeenInvoked = false;
 
@@ -88,8 +88,7 @@ exports.runWebpackCompiler = function runWebpackCompiler(config, $mobileHelper, 
                     }
 
                     if (hookArgs.filesToSync && hookArgs.startSyncFilesTimeout) {
-                        // TODO: Might need to get the "app" constant from config file in the future
-                        hookArgs.filesToSync.push(...message.emittedFiles.map(emittedFile => join("app", emittedFile)));
+                        hookArgs.filesToSync.push(...message.emittedFiles.map(emittedFile => join(AppDirectoryLocation, emittedFile)));
                         hookArgs.startSyncFilesTimeout();
                     }
                 }

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -84,7 +84,7 @@ exports.runWebpackCompiler = function runWebpackCompiler(config, $mobileHelper, 
                     }
 
                     if (hookArgs.filesToSync && hookArgs.startSyncFilesTimeout) {
-                        hookArgs.filesToSync.push(...message.emittedFiles.map(emittedFile => join(AppDirectoryLocation, emittedFile)));
+                        hookArgs.filesToSync.push(...message.emittedFiles.map(emittedFile => join($projectData.projectDir, AppDirectoryLocation, emittedFile)));
                         hookArgs.startSyncFilesTimeout();
                     }
                 }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,3 @@
+module.exports = {
+	AppDirectoryLocation: "app"
+};

--- a/package.json
+++ b/package.json
@@ -21,6 +21,16 @@
         "inject": true
       },
       {
+        "type": "before-watch",
+        "script": "lib/before-watch.js",
+        "inject": true
+      },
+      {
+        "type": "before-watchPatterns",
+        "script": "lib/before-watchPatterns.js",
+        "inject": true
+      },
+      {
         "type": "after-prepare",
         "script": "lib/after-prepare.js",
         "inject": true

--- a/plugins/WatchStateLoggerPlugin.ts
+++ b/plugins/WatchStateLoggerPlugin.ts
@@ -13,7 +13,7 @@ export class WatchStateLoggerPlugin {
     isRunningWatching: boolean;
     apply(compiler) {
         const plugin = this;
-        compiler.plugin("watch-run", function(compiler, callback) {
+        compiler.plugin("watch-run", function (compiler, callback) {
             plugin.isRunningWatching = true;
             if (plugin.isRunningWatching) {
                 console.log(messages.changeDetected);
@@ -21,14 +21,21 @@ export class WatchStateLoggerPlugin {
             process.send && process.send(messages.changeDetected, error => null);
             callback();
         });
-        compiler.plugin("after-emit", function(compilation, callback) {
+        compiler.plugin("after-emit", function (compilation, callback) {
             callback();
             if (plugin.isRunningWatching) {
                 console.log(messages.startWatching);
             } else {
                 console.log(messages.compilationComplete);
             }
+
+            const emittedFiles = Object
+                .keys(compilation.assets)
+                .filter(assetKey => compilation.assets[assetKey].emitted);
+
             process.send && process.send(messages.compilationComplete, error => null);
+            // Send emitted files so they can be LiveSynced if need be
+            process.send && process.send({ emittedFiles }, error => null);
         });
     }
 }

--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -20,6 +20,9 @@ module.exports = env => {
 
     const config = {
         context: resolve("./app"),
+        watchOptions: {
+            ignored: resolve("./app/App_Resources")
+        },
         target: nativescriptTarget,
         entry: {
             bundle: aot ? "./main.aot.ts" : "./main.ts",

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -18,6 +18,9 @@ module.exports = env => {
 
     const config = {
         context: resolve("./app"),
+        watchOptions: {
+            ignored: resolve("./app/App_Resources")
+        },
         target: nativescriptTarget,
         entry: {
             bundle: `./${nsWebpack.getEntryModule()}`,

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -18,6 +18,9 @@ module.exports = env => {
 
     const config = {
         context: resolve("./app"),
+        watchOptions: {
+            ignored: resolve("./app/App_Resources")
+        },
         target: nativescriptTarget,
         entry: {
             bundle: `./${nsWebpack.getEntryModule()}`,


### PR DESCRIPTION
Plug into NativeScript CLI's LiveSync pipeline in order to enable incremental webpacking with watch.
Includes:
* Instruct CLI to watch `App_Resources` directory only
* Launch `webpack` with `--watch` on before-watch hook
* Do not launch multiple `webpack` processes

Merge after https://github.com/NativeScript/nativescript-cli/pull/3350
Implements https://github.com/NativeScript/nativescript-cli/issues/3349

Ping @sis0k0 @rosen-vladimirov @KristianDD 