### PR TITLE
feat: consume shouldprepare hook

### DIFF
--- a/lib/before-shouldPrepare.js
+++ b/lib/before-shouldPrepare.js
@@ -1,0 +1,24 @@
+const { join } = require("path");
+const { readFileSync, existsSync, writeFileSync } = require("fs");
+const envOptionsCacheFileLocation = join(__dirname, "env.cache.json");
+
+module.exports = function (hookArgs) {
+	const platformInfo = hookArgs.shouldPrepareInfo && hookArgs.shouldPrepareInfo.platformInfo;
+	if (platformInfo && platformInfo.appFilesUpdaterOptions && platformInfo.appFilesUpdaterOptions.bundle) {
+		return (args, originalMethod) => {
+			return originalMethod(...args).then(originalShouldPrepare => {
+				const currentEnvString = JSON.stringify(platformInfo.env || {});
+				if (existsSync(envOptionsCacheFileLocation)) {
+					const oldEnvOptionsString = readFileSync(envOptionsCacheFileLocation).toString();
+					if (oldEnvOptionsString === currentEnvString) {
+						return originalShouldPrepare;
+					}
+				}
+
+				writeFileSync(envOptionsCacheFileLocation, currentEnvString);
+
+				return true;
+			});
+		};
+	}
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
         "inject": true
       },
       {
+        "type": "before-shouldPrepare",
+        "script": "lib/before-shouldPrepare.js",
+        "inject": true
+      },
+      {
         "type": "after-prepare",
         "script": "lib/after-prepare.js",
         "inject": true


### PR DESCRIPTION
Consume `shouldPrepare` hook in order to control when CLI should prepare the project.
Project should be prepared every time webpack is invoked with different `env` options.
(e.g. first run was `tns run android --bundle` and the second run is `tns run android --bundle --env.uglify`)

Merge after https://github.com/NativeScript/nativescript-cli/pull/3399
Ping @rosen-vladimirov @sis0k0 