### PR TITLE
fix-next: send arguments in watchPatterns hook

### DIFF
--- a/lib/before-watchPatterns.js
+++ b/lib/before-watchPatterns.js
@@ -3,7 +3,7 @@ const { AppDirectoryLocation } = require("./constants");
 module.exports = function (hookArgs) {
 	if (hookArgs.liveSyncData && hookArgs.liveSyncData.bundle) {
 		return (args, originalMethod) => {
-			return originalMethod().then(originalPatterns => {
+			return originalMethod(...args).then(originalPatterns => {
 				const appDirectoryLocationIndex = originalPatterns.indexOf(AppDirectoryLocation);
 				if (appDirectoryLocationIndex !== -1) {
 					originalPatterns.splice(appDirectoryLocationIndex, 1);


### PR DESCRIPTION
Need to send the arguments when we call the original method inside before-watchPatterns hook.