### PR TITLE
fix: remove progress indication

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -58,7 +58,6 @@ exports.runWebpackCompiler = function runWebpackCompiler(config, $projectData, $
                 ...sourceMapSupportArgs,
                 pathResolve(projectDir, "node_modules", "webpack", "bin", "webpack.js"),
                 `--config=${pathResolve(projectDir, "webpack.config.js")}`,
-                "--progress",
                 ...(config.watch ? ["--watch"] : []),
                 ...envParams,
             ].filter(a => !!a);


### PR DESCRIPTION
Remove progress indication as `webpack` [prints said indication on the `stderr`](https://github.com/webpack/webpack/blob/4428efe48e1c5ff4cadb79e13f0fa48c12bdac35/lib/ProgressPlugin.js#L50) which confuses some tools

Ping @sis0k0 