### PR TITLE
fix-next: export uglifyMangleExcludes for backwards compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,9 @@ exports.getAotEntryModule = function (appDirectory = APP_PATH) {
     return aotEntry;
 }
 
+// Exported for backwards compatibility
+exports.uglifyMangleExcludes = [];
+
 exports.getEntryModule = function (appDirectory = APP_PATH) {
     const entry = getPackageJsonEntry(appDirectory);
 


### PR DESCRIPTION
Export an empty array for `uglifyMangleExcludes` to prevent crashes when using older webpack configurations.

related to #461 