### PR TITLE
fix: remove unnecessary comma

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,7 +19,7 @@ function buildEnvData($projectData, platform, env) {
     const appResourcesPath = getAppResourcesPathFromProjectData($projectData);
     Object.assign(envData,
         appPath && { appPath },
-        appResourcesPath && { appResourcesPath },
+        appResourcesPath && { appResourcesPath }
     );
 
     return envData;


### PR DESCRIPTION
This excessive comma provokes some strange behavior on nodejs 6 and the file cannot be `require`d.

Ping @sis0k0 