### PR TITLE
fix-next(nsCliHelpers): return undefined if no global CLI

### DIFF
--- a/nsCliHelpers.js
+++ b/nsCliHelpers.js
@@ -7,6 +7,10 @@ const PROJECT_DATA_GETTERS = {
 
 function getProjectData(projectDir) {
     const cli = getNsCli();
+    if (!cli) {
+      return {};
+    }
+
     const projectDataService = cli.projectDataService;
     const projectData = safeGet(cli, "getProjectData", projectDir);
 
@@ -15,6 +19,10 @@ function getProjectData(projectDir) {
 
 function getNsCli() {
     const cliPath = getPath("nativescript", "tns");
+    if (!cliPath) {
+        return;
+    }
+
     const cli = require(cliPath);
 
     return cli;


### PR DESCRIPTION
The plugin should fall back to using some default project settings (`appPath: 'app'`, `appResourcesPath: 'app/App_Resources'`) if {N} CLI is not globally installed.

Steps to test:
1. Create new {N} project:
```
tns create my-project
cd my-project
```
2. Uninstall {N} CLI:
```
npm uninstall -g nativescript
```
> If you're using nvm it wouble be enough to set up an empty workspace by installing a new node version. For example - `nvm install 9.9.0`.

3. Install `nativescript-dev-webpack` from the current PR's branch:
```
npm i nativescript/nativescript-dev-webpack#sis0k0/return-if-no-tns
```

**Expected behaviour**
The plugin should be installed successfully and `vendor.ts`, `vendor-platform.android.ts` and `vendor-platform.ios.ts` should be added inside the app/ dir.

**Current behaviour**
The postinstall script fails while trying to find globally installed `tns`.