### PR TITLE
fix: Hooks are not executed correctly when CLI is used as a library

### DIFF
--- a/lib/after-prepare.js
+++ b/lib/after-prepare.js
@@ -1,7 +1,7 @@
 const { installSnapshotArtefacts } = require("../snapshot/android/project-snapshot-generator");
 const { shouldSnapshot } = require("./utils");
 
-module.exports = function ($projectData, hookArgs) {
+module.exports = function (hookArgs) {
 	const env = hookArgs.env || {};
 	const shouldSnapshotOptions = {
 		platform: hookArgs.platform,
@@ -10,6 +10,6 @@ module.exports = function ($projectData, hookArgs) {
 	};
 
 	if (env.snapshot && shouldSnapshot(shouldSnapshotOptions)) {
-		installSnapshotArtefacts($projectData.projectDir);
+		installSnapshotArtefacts(hookArgs.projectData.projectDir);
 	}
 }

--- a/lib/before-prepareJS.js
+++ b/lib/before-prepareJS.js
@@ -1,6 +1,6 @@
 const { runWebpackCompiler } = require("./compiler");
 
-module.exports = function ($projectData, $logger, hookArgs) {
+module.exports = function ($logger, hookArgs) {
     const env = hookArgs.config.env || {};
     const platform = hookArgs.config.platform;
     const appFilesUpdaterOptions = hookArgs.config.appFilesUpdaterOptions;
@@ -10,6 +10,6 @@ module.exports = function ($projectData, $logger, hookArgs) {
         bundle: appFilesUpdaterOptions.bundle,
         release: appFilesUpdaterOptions.release,
     };
-    const result = config.bundle && runWebpackCompiler.bind(runWebpackCompiler, config, $projectData, $logger, hookArgs);
+    const result = config.bundle && runWebpackCompiler.bind(runWebpackCompiler, config, hookArgs.config.projectData, $logger, hookArgs);
     return result;
 }

--- a/lib/before-watch.js
+++ b/lib/before-watch.js
@@ -1,6 +1,6 @@
 const { runWebpackCompiler } = require("./compiler");
 
-module.exports = function ($projectData, $logger, hookArgs) {
+module.exports = function ($logger, hookArgs) {
 	if (hookArgs.config) {
 		const appFilesUpdaterOptions = hookArgs.config.appFilesUpdaterOptions;
 		if (appFilesUpdaterOptions.bundle) {
@@ -15,7 +15,7 @@ module.exports = function ($projectData, $logger, hookArgs) {
 					watch: true
 				};
 
-				return runWebpackCompiler(config, $projectData, $logger, hookArgs);
+				return runWebpackCompiler(config, hookArgs.projectData, $logger, hookArgs);
 			}));
 		}
 	}

--- a/lib/before-watchPatterns.js
+++ b/lib/before-watchPatterns.js
@@ -5,13 +5,13 @@ const {
     setProcessInitDirectory,
 } = require("./utils");
 
-module.exports = function ($projectData, hookArgs) {
+module.exports = function (hookArgs) {
     const { liveSyncData } = hookArgs;
     if (!liveSyncData || !liveSyncData.bundle) {
         return;
     }
 
-    setProcessInitDirectory($projectData.projectDir);
+    setProcessInitDirectory(hookArgs.projectData.projectDir);
     const { platforms } = hookArgs;
     const { env } = liveSyncData;
     return (args, originalMethod) => {
@@ -21,7 +21,7 @@ module.exports = function ($projectData, hookArgs) {
             }
 
             const compilationContexts = platforms.map(platform =>
-                getContext($projectData, platform, env));
+                getContext(hookArgs.projectData, platform, env));
 
             const ignorePatterns = compilationContexts.map(
                 context => `!${context}`
@@ -32,7 +32,7 @@ module.exports = function ($projectData, hookArgs) {
     };
 }
 
-function getContext($projectData, platform, env) {
-    const fullEnvData = buildEnvData($projectData, platform, env);
-    return getCompilationContext($projectData.projectDir, fullEnvData);
+function getContext(projectData, platform, env) {
+    const fullEnvData = buildEnvData(projectData, platform, env);
+    return getCompilationContext(projectData.projectDir, fullEnvData);
 }


### PR DESCRIPTION
When CLI is used as a library, the `$projectData` is not populated. Instead of using this injected dependency in the hooks, the projectData should be taken from the hookArgs or from the `projectDataService`.
Fix all hooks, so the correct projectData is used.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Trying to use webpack builds from CLI, when CLI is used as a library, leads to different errors as the projectData is not correct.

## What is the new behavior?
The hooks take the correct data from hookArgs or projectDataService and the build with webpack works when CLI is used as a library
