### PR TITLE
fix: Set INIT_CWD env in all before-* hooks

### DIFF
--- a/lib/before-cleanApp.js
+++ b/lib/before-cleanApp.js
@@ -1,8 +1,11 @@
 const { cleanSnapshotArtefacts } = require("../snapshot/android/project-snapshot-generator");
 const { isAndroid } = require("../projectHelpers");
+const { setProcessInitDirectory } = require("./utils");
 
 module.exports = function (hookArgs) {
     if (isAndroid(hookArgs.platformInfo.platform)) {
-        cleanSnapshotArtefacts(hookArgs.platformInfo.projectData.projectDir);
+        const projectDir = hookArgs.platformInfo.projectData.projectDir;
+        setProcessInitDirectory(projectDir);
+        cleanSnapshotArtefacts(projectDir);
     }
 }

--- a/lib/before-prepareJS.js
+++ b/lib/before-prepareJS.js
@@ -1,4 +1,5 @@
 const { runWebpackCompiler } = require("./compiler");
+const { setProcessInitDirectory } = require("./utils");
 
 module.exports = function ($logger, hookArgs) {
     const env = hookArgs.config.env || {};
@@ -10,6 +11,10 @@ module.exports = function ($logger, hookArgs) {
         bundle: appFilesUpdaterOptions.bundle,
         release: appFilesUpdaterOptions.release,
     };
-    const result = config.bundle && runWebpackCompiler.bind(runWebpackCompiler, config, hookArgs.config.projectData, $logger, hookArgs);
+
+    const projectData = hookArgs.config.projectData;
+    setProcessInitDirectory(projectData.projectDir);
+
+    const result = config.bundle && runWebpackCompiler.bind(runWebpackCompiler, config, projectData, $logger, hookArgs);
     return result;
 }

--- a/lib/before-shouldPrepare.js
+++ b/lib/before-shouldPrepare.js
@@ -1,10 +1,13 @@
 const { join } = require("path");
 const { readFileSync, existsSync, writeFileSync } = require("fs");
+const { setProcessInitDirectory } = require("./utils");
 const envOptionsCacheFileLocation = join(__dirname, "env.cache.json");
 
 module.exports = function (hookArgs) {
 	const platformInfo = hookArgs.shouldPrepareInfo && hookArgs.shouldPrepareInfo.platformInfo;
 	if (platformInfo && platformInfo.appFilesUpdaterOptions && platformInfo.appFilesUpdaterOptions.bundle) {
+		setProcessInitDirectory(platformInfo.projectData.projectDir);
+
 		return (args, originalMethod) => {
 			return originalMethod(...args).then(originalShouldPrepare => {
 				const currentEnvString = JSON.stringify(platformInfo.env || {});

--- a/lib/before-watch.js
+++ b/lib/before-watch.js
@@ -1,4 +1,5 @@
 const { runWebpackCompiler } = require("./compiler");
+const { setProcessInitDirectory } = require("./utils");
 
 module.exports = function ($logger, hookArgs) {
 	if (hookArgs.config) {
@@ -15,7 +16,9 @@ module.exports = function ($logger, hookArgs) {
 					watch: true
 				};
 
-				return runWebpackCompiler(config, hookArgs.projectData, $logger, hookArgs);
+				const projectData = hookArgs.projectData;
+				setProcessInitDirectory(projectData.projectDir);
+				return runWebpackCompiler(config, projectData, $logger, hookArgs);
 			}));
 		}
 	}


### PR DESCRIPTION
In a long living process, where the project can be changed, we need to set
the INIT_CWD environment variable in all before-* hooks. Currently it is
set only in the `before-watchPatterns` hook. This way, when we use webpack
for a project and later we try to use webpack for another project, we try
to execute some operations based on the INIT_CWD directory, which still
points to our old project. In order to fix this unexpected behavior, set
the INIT_CWD in all before-* hooks, as some of them may be skipped based
on the state of the project.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Currently when you try to use webpack to build more than one project in the same process (for example in Sidekick), the INIT_CWD variable is set when the first project is built. When the next project should be build, the INIT_CWD env variable is already set and the hooks of the second project are not executed correctly as they search for their resources in the first project.

## What is the new behavior?
Set INIT_CWD environment variable in all before-* hooks, so multiple projects can be build in the same process.

[CLA]: http://www.nativescript.org/cla