### PR TITLE
fix(hooks): `after-watch` hook is not executed

### DIFF
--- a/lib/after-watch.js
+++ b/lib/after-watch.js
@@ -3,6 +3,6 @@ module.exports = function($logger) {
     const webpackProcess = compiler.getWebpackProcess();
     if (webpackProcess) {
         $logger.info("Stopping webpack watch");
-        webpack.kill("SIGINT");
+        webpackProcess.kill("SIGINT");
     }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
         "inject": true
       },
       {
+        "type": "after-watch",
+        "script": "lib/after-watch.js",
+        "inject": true
+      },
+      {
         "type": "before-watchPatterns",
         "script": "lib/before-watchPatterns.js",
         "inject": true


### PR DESCRIPTION
The `after-watch` hook is not executed as it is not registered in the package.json. So it is never created in the projects, so the webpack process is not stopped when LiveSync should stop.
In CLI process this is not a problem, but this is a huge issue for Sidekick, as the webpack watcher keeps watching the project and executes some actions.

Also fix the code in the hook itself - the `webpack` variable does not exist.
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
When webpack is used for LiveSync, once the LiveSync operation should stop, the after watch hook should be executed. As it is never registered in the project, the webpack watcher remains alive and continues watching the project.

## What is the new behavior?
When the LiveSync should be stopped, the after-watch hook is executed and the webpack process is killed.
