### PR TITLE
chore: Do not set INIT_CWD on any hook

### DIFF
--- a/lib/before-cleanApp.js
+++ b/lib/before-cleanApp.js
@@ -1,11 +1,8 @@
 const { cleanSnapshotArtefacts } = require("../snapshot/android/project-snapshot-generator");
 const { isAndroid } = require("../projectHelpers");
-const { setProcessInitDirectory } = require("./utils");
 
 module.exports = function (hookArgs) {
     if (isAndroid(hookArgs.platformInfo.platform)) {
-        const projectDir = hookArgs.platformInfo.projectData.projectDir;
-        setProcessInitDirectory(projectDir);
-        cleanSnapshotArtefacts(projectDir);
+        cleanSnapshotArtefacts(hookArgs.platformInfo.projectData.projectDir);
     }
 }

--- a/lib/before-prepareJS.js
+++ b/lib/before-prepareJS.js
@@ -1,5 +1,4 @@
 const { runWebpackCompiler } = require("./compiler");
-const { setProcessInitDirectory } = require("./utils");
 
 module.exports = function ($logger, hookArgs) {
     const env = hookArgs.config.env || {};
@@ -12,9 +11,6 @@ module.exports = function ($logger, hookArgs) {
         release: appFilesUpdaterOptions.release,
     };
 
-    const projectData = hookArgs.config.projectData;
-    setProcessInitDirectory(projectData.projectDir);
-
-    const result = config.bundle && runWebpackCompiler.bind(runWebpackCompiler, config, projectData, $logger, hookArgs);
+    const result = config.bundle && runWebpackCompiler.bind(runWebpackCompiler, config, hookArgs.config.projectData, $logger, hookArgs);
     return result;
 }

--- a/lib/before-shouldPrepare.js
+++ b/lib/before-shouldPrepare.js
@@ -1,12 +1,10 @@
 const { join } = require("path");
 const { readFileSync, existsSync, writeFileSync } = require("fs");
-const { setProcessInitDirectory } = require("./utils");
 const envOptionsCacheFileLocation = join(__dirname, "env.cache.json");
 
 module.exports = function (hookArgs) {
 	const platformInfo = hookArgs.shouldPrepareInfo && hookArgs.shouldPrepareInfo.platformInfo;
 	if (platformInfo && platformInfo.appFilesUpdaterOptions && platformInfo.appFilesUpdaterOptions.bundle) {
-		setProcessInitDirectory(platformInfo.projectData.projectDir);
 
 		return (args, originalMethod) => {
 			return originalMethod(...args).then(originalShouldPrepare => {

--- a/lib/before-watch.js
+++ b/lib/before-watch.js
@@ -1,5 +1,4 @@
 const { runWebpackCompiler } = require("./compiler");
-const { setProcessInitDirectory } = require("./utils");
 
 module.exports = function ($logger, hookArgs) {
 	if (hookArgs.config) {
@@ -16,9 +15,7 @@ module.exports = function ($logger, hookArgs) {
 					watch: true
 				};
 
-				const projectData = hookArgs.projectData;
-				setProcessInitDirectory(projectData.projectDir);
-				return runWebpackCompiler(config, projectData, $logger, hookArgs);
+				return runWebpackCompiler(config, hookArgs.projectData, $logger, hookArgs);
 			}));
 		}
 	}

--- a/lib/before-watchPatterns.js
+++ b/lib/before-watchPatterns.js
@@ -2,7 +2,6 @@ const { basename } = require("path");
 const {
     buildEnvData,
     getCompilationContext,
-    setProcessInitDirectory,
 } = require("./utils");
 
 module.exports = function (hookArgs) {
@@ -11,7 +10,6 @@ module.exports = function (hookArgs) {
         return;
     }
 
-    setProcessInitDirectory(hookArgs.projectData.projectDir);
     const { platforms } = hookArgs;
     const { env } = liveSyncData;
     return (args, originalMethod) => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -41,13 +41,8 @@ function shouldSnapshot(config) {
     return config.bundle && config.release && platformSupportsSnapshot && osSupportsSnapshot;
 }
 
-function setProcessInitDirectory(dir) {
-    process.env.INIT_CWD = dir;
-}
-
 module.exports = {
     buildEnvData,
     getCompilationContext,
-    shouldSnapshot,
-    setProcessInitDirectory,
+    shouldSnapshot
 };


### PR DESCRIPTION
Previously the INIT_CWD environment variable was set only in one of the hooks. In a recent PR, we've changed the logic of all `before-*` hooks to set the INIT_CWD environment variable.
After some discussions and investigation, we've found that we do not need the INIT_CWD variable. So remove the setting of the variable from all hooks and delete the method that sets it.

This PR is a combination of:
- revert this PR: https://github.com/NativeScript/nativescript-dev-webpack/pull/480
- fix the issue that the same PR fixes

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
All before-*  hooks set the INIT_CWD environment variable.

## What is the new behavior?
None of the hooks set the INIT_CWD environment variable.
