### PR TITLE
Compare webpack.config files

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -3,9 +3,14 @@
 const { dirname } = require("path");
 const hook = require("nativescript-hook")(__dirname);
 
+const { compareProjectFiles } = require("./projectFilesManager");
 const { getProjectDir } = require("./projectHelpers");
 
-if (getProjectDir()) {
+const projectDir = getProjectDir();
+
+if (projectDir) {
+    compareProjectFiles(projectDir);
+
     hook.postinstall();
     const installer = require("./installer");
     installer.install();

--- a/projectFilesManager.js
+++ b/projectFilesManager.js
@@ -37,6 +37,21 @@ function forceUpdateProjectFiles(projectDir, appDir) {
     addProjectFiles(projectDir, appDir);
 }
 
+function compareProjectFiles(projectDir) {
+    const projectTemplates = getProjectTemplates(projectDir);
+    Object.keys(projectTemplates).forEach(function(newTemplatePath){
+        const currentTemplatePath = projectTemplates[newTemplatePath];
+        if (fs.existsSync(currentTemplatePath)) {
+            const currentTemplate = fs.readFileSync(currentTemplatePath).toString();
+            const newTemplate = fs.readFileSync(newTemplatePath).toString();
+            if (newTemplate !== currentTemplate) {
+                const message = `The current project contains a ${path.basename(currentTemplatePath)} file located at ${currentTemplatePath} that differs from the one in the new version of the nativescript-dev-webpack plugin located at ${newTemplatePath}. Some of the plugin features may not work as expected until you manually update the ${path.basename(currentTemplatePath)} file.`;
+                console.info(`\x1B[33;1m${message}\x1B[0m` );
+            }
+        }
+    });
+}
+
 function deleteFile(destinationPath) {
     if (fs.existsSync(destinationPath)) {
         console.info(`Deleting file: ${destinationPath}`);
@@ -108,5 +123,6 @@ module.exports = {
     addProjectFiles,
     removeProjectFiles,
     forceUpdateProjectFiles,
+    compareProjectFiles,
 };
 

--- a/projectFilesManager.js
+++ b/projectFilesManager.js
@@ -39,13 +39,13 @@ function forceUpdateProjectFiles(projectDir, appDir) {
 
 function compareProjectFiles(projectDir) {
     const projectTemplates = getProjectTemplates(projectDir);
-    Object.keys(projectTemplates).forEach(function(newTemplatePath){
+    Object.keys(projectTemplates).forEach(newTemplatePath => {
         const currentTemplatePath = projectTemplates[newTemplatePath];
         if (fs.existsSync(currentTemplatePath)) {
             const currentTemplate = fs.readFileSync(currentTemplatePath).toString();
             const newTemplate = fs.readFileSync(newTemplatePath).toString();
             if (newTemplate !== currentTemplate) {
-                const message = `The current project contains a ${path.basename(currentTemplatePath)} file located at ${currentTemplatePath} that differs from the one in the new version of the nativescript-dev-webpack plugin located at ${newTemplatePath}. Some of the plugin features may not work as expected until you manually update the ${path.basename(currentTemplatePath)} file.`;
+                const message = `The current project contains a ${path.basename(currentTemplatePath)} file located at ${currentTemplatePath} that differs from the one in the new version of the nativescript-dev-webpack plugin located at ${newTemplatePath}. Some of the plugin features may not work as expected until you manually update the ${path.basename(currentTemplatePath)} file or automatically update it using "./node_modules/.bin/update-ns-webpack --configs" command.`;
                 console.info(`\x1B[33;1m${message}\x1B[0m` );
             }
         }


### PR DESCRIPTION
Compare current webpack.config.js and the one that will come from the installing version of nativescript-dev-webpack plugin and in case when they are different print a warning message.

## PR Checklist

- [x ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
When the user has a project with already generated `webpack.config.js` and update `nativescript-dev-webpack` plugin to newer version, `webpack.config.js` is not replaced and this way if the newer version of `nativescript-dev-webpack` has changes in `webpack.config.js` file they are not respected in user project.

## What is the new behavior?
When the user has a project with already generated `webpack.config.js` and update `nativescript-dev-webpack` plugin to newer version which has changes in `webpack.config.js` file, a warning message if printed to ask the user to manually update the file.
