### PR TITLE
chore: update dependency - nativescript-hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "global-modules-path": "2.0.0",
     "minimatch": "3.0.4",
-    "nativescript-hook": "0.2.3",
+    "nativescript-hook": "0.2.4",
     "proxy-lib": "0.4.0",
     "request": "2.83.0",
     "schema-utils": "0.4.3",


### PR DESCRIPTION
Update nativescript-hook to 0.2.4. Release notes: https://github.com/NativeScript/nativescript-hook/releases/tag/v0.2.4

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
In case you have hooks already installed, but you delete your node_modules, calling `npm install` will execute postinstall scripts of the packages and you'll see messages like:
```
Hook already installed: nativescript-dev-webpack
```
This message does not give enough information for the location of the hook.

## What is the new behavior?
In case you have hooks already installed, but you delete your node_modules, calling `npm install` will execute postinstall scripts of the packages and you'll see messages like:
```
Hook already installed: nativescript-dev-webpack at location `<project dir>/hooks/before-prepareJs`
```

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla