### PR TITLE
feat: configure v8Version for snapshot tools

### DIFF
--- a/plugins/NativeScriptSnapshotPlugin/index.js
+++ b/plugins/NativeScriptSnapshotPlugin/index.js
@@ -64,7 +64,7 @@ exports.NativeScriptSnapshotPlugin = (function() {
             targetArchs: options.targetArchs,
             useLibs: options.useLibs,
             androidNdkPath: options.androidNdkPath,
-            v8Version: this.options.v8Version,
+            v8Version: options.v8Version,
             tnsJavaClassesPath: join(preparedAppRootPath, "tns-java-classes.js")
         }).then(() => {
             // Make the original file empty

--- a/plugins/NativeScriptSnapshotPlugin/index.js
+++ b/plugins/NativeScriptSnapshotPlugin/index.js
@@ -64,6 +64,7 @@ exports.NativeScriptSnapshotPlugin = (function() {
             targetArchs: options.targetArchs,
             useLibs: options.useLibs,
             androidNdkPath: options.androidNdkPath,
+            v8Version: this.options.v8Version,
             tnsJavaClassesPath: join(preparedAppRootPath, "tns-java-classes.js")
         }).then(() => {
             // Make the original file empty

--- a/plugins/NativeScriptSnapshotPlugin/options.json
+++ b/plugins/NativeScriptSnapshotPlugin/options.json
@@ -25,6 +25,9 @@
     },
     "useLibs": {
       "type": "boolean"
+    },
+    "v8Version": {
+        "type": "string"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
v8Version which will be used for snapshot generation can be passed now to NativeScriptSnapshotPlugin options