### PR TITLE
fix: bundling of Angular apps using linked TS plugins

### DIFF
--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -69,17 +69,17 @@ module.exports = env => {
             extensions: [".ts", ".js", ".scss", ".css"],
             // Resolve {N} system modules from tns-core-modules
             modules: [
+                resolve(__dirname, "node_modules/tns-core-modules"),
+                resolve(__dirname, "node_modules"),
                 "node_modules/tns-core-modules",
                 "node_modules",
             ],
             alias: {
                 '~': appFullPath
             },
-            // don't resolve symlinks to symlinked modules
-            symlinks: false
+            symlinks: true
         },
         resolveLoader: {
-            // don't resolve symlinks to symlinked loaders
             symlinks: false
         },
         node: {


### PR DESCRIPTION
- the webpack build is now following the symLinks in Angular apps
- the root node_modules folder of the app now takes precedence over the local node_modules during module resolution (avoiding duplicate modules in the bundle when following symLinks) 

## What is the current behavior?
When you try to build the Angular demo of a plugin and the plugin source is linked in the demo, you will receive the following exception:

> Error: ...`demo-angular/node_modules/nativescript-your-plugin/your-plugin.ts` is missing from the TypeScript compilation. Please make sure it is in your tsconfig via the 'files' or 'include' property.
> The missing file seems to be part of a third party library. TS files in published libraries are often a sign of a badly packaged library. TS files in published libraries are often a sign of a badly packaged library. Please open an issue in the library repository to alert its author and ask them to package the library using the Angular Package Format (https://goo.gl/jB3GVv).
at NativeScriptAngularCompilerPlugin.getCompiledFile...

and even if you include the problematic `demo-angular/node_modules/nativescript-your-plugin/your-plugin.ts` file using the `files` or `include` tsconfig properties as described in the exception message, you will still get the same error because the file is linked and this is not its real location.

## What is the new behavior?
When you try to build the Angular demo of a plugin and the plugin source is linked in the demo, you will receive the following exception:

> Error: ...`src/your-plugin.ts` is missing from the TypeScript compilation. Please make sure it is in your tsconfig via the 'files' or 'include' property.
at NativeScriptAngularCompilerPlugin.getCompiledFile...

and when you include the problematic `src/your-plugin.ts` file using the `files` or `include` tsconfig properties as described in the exception message, you will get the app built and running.

## Why in Angular apps only?
It seems that the `@ngtools/webpack` typescript loader used in the Angular apps requires real paths to the ts files, while the `awesome-typescript-loader` used in the Typescript NativeScript apps is working fine with the linked paths.  