### PR TITLE
refactor: remove android-runtime 3.4< specific code

### DIFF
--- a/androidProjectHelpers.js
+++ b/androidProjectHelpers.js
@@ -1,0 +1,52 @@
+const { join, resolve } = require("path");
+const { existsSync, readFileSync } = require("fs");
+
+const { getPackageJson } = require("./projectHelpers");
+
+const PLATFORMS_ANDROID = "platforms/android";
+const ANDROID_PROJECT_DIR = join(PLATFORMS_ANDROID, "app");
+const ANDROID_APP_PATH = join(ANDROID_PROJECT_DIR, "src/main/assets/app");
+const ANDROID_CONFIGURATIONS_PATH = join(ANDROID_PROJECT_DIR, "build/configurations");
+
+const getAndroidRuntimeVersion = (projectDir) => {
+    try {
+        const projectPackageJSON = getPackageJson(projectDir);
+
+        const version = projectPackageJSON["nativescript"]["tns-android"]["version"];
+        return version && toReleaseVersion(version);
+    } catch (e) {
+        return null;
+    }
+}
+
+const toReleaseVersion = version => version.replace(/-.*/, "");
+
+const getAndroidV8Version = (projectDir) => {
+    try {
+        const androidSettingsJSON = getAndroidSettingsJson(projectDir);
+        if (androidSettingsJSON !== null) {
+            return androidSettingsJSON.v8Version;
+        } else {
+            return null;
+        }
+    } catch (e) {
+        return null;
+    }
+}
+
+const getAndroidSettingsJson = projectDir => {
+    const androidSettingsJsonPath = resolve(projectDir, PLATFORMS_ANDROID, "settings.json");
+    if (existsSync(androidSettingsJsonPath)) {
+        return JSON.parse(readFileSync(androidSettingsJsonPath, "utf8"));
+    } else {
+        return null;
+    }
+};
+
+module.exports = {
+    ANDROID_PROJECT_DIR,
+    ANDROID_APP_PATH,
+    ANDROID_CONFIGURATIONS_PATH,
+    getAndroidRuntimeVersion,
+    getAndroidV8Version,
+};

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 const path = require("path");
 const { existsSync } = require("fs");
 
+const { ANDROID_APP_PATH } = require("./androidProjectHelpers");
 const {
     getPackageJson,
     isAngular,
     isAndroid,
     isIos,
-    resolveAndroidAppPath,
 } = require("./projectHelpers");
 
 Object.assign(exports, require('./plugins'));
@@ -54,7 +54,7 @@ exports.getAppPath = (platform, projectDir) => {
 
         return `platforms/ios/${sanitizedName}/app`;
     } else if (isAndroid(platform)) {
-        return resolveAndroidAppPath(projectDir);
+        return ANDROID_APP_PATH;
     } else {
         throw new Error(`Invalid platform: ${platform}`);
     }

--- a/plugins/NativeScriptSnapshotPlugin/index.js
+++ b/plugins/NativeScriptSnapshotPlugin/index.js
@@ -3,7 +3,10 @@ const { closeSync, openSync, writeFileSync } = require("fs");
 const validateOptions = require("schema-utils");
 
 const ProjectSnapshotGenerator = require("../../snapshot/android/project-snapshot-generator");
-const { resolveAndroidAppPath, getAndroidProjectPath } = require("../../projectHelpers");
+const {
+    ANDROID_PROJECT_DIR,
+    ANDROID_APP_PATH,
+} = require("../../androidProjectHelpers");
 const schema = require("./options.json");
 
 const SNAPSHOT_ENTRY_NAME = "snapshot-entry";
@@ -34,10 +37,9 @@ exports.NativeScriptSnapshotPlugin = (function() {
     }
 
     NativeScriptSnapshotPlugin.ensureSnapshotModuleEntry = function(options) {
-        const { webpackConfig, requireModules, chunks, projectRoot, includeApplicationCss } = options;
+        const { webpackConfig, requireModules, chunks, includeApplicationCss } = options;
 
-        const androidProjectPath = getAndroidProjectPath({ projectRoot: projectRoot });
-        const snapshotEntryPath = join(androidProjectPath, SNAPSHOT_ENTRY_MODULE);
+        const snapshotEntryPath = join(ANDROID_PROJECT_DIR, SNAPSHOT_ENTRY_MODULE);
 
         let snapshotEntryContent = "";
         if (includeApplicationCss) {
@@ -81,10 +83,13 @@ exports.NativeScriptSnapshotPlugin = (function() {
     NativeScriptSnapshotPlugin.prototype.generate = function (webpackChunks) {
         const options = this.options;
         const inputFiles = webpackChunks.map(chunk => join(options.webpackConfig.output.path, chunk.files[0]));
-        console.log(`\n Snapshotting bundle from ${inputFiles}`);
+        const preprocessedInputFile = join(
+            this.options.projectRoot,
+            ANDROID_APP_PATH,
+            "_embedded_script_.js"
+        );
 
-        const preparedAppRootPath = resolveAndroidAppPath(this.options.projectRoot);
-        const preprocessedInputFile = join(preparedAppRootPath, "_embedded_script_.js");
+        console.log(`\n Snapshotting bundle from ${inputFiles}`);
 
         return ProjectSnapshotGenerator.prototype.generate.call(this, {
             inputFiles,

--- a/snapshot/android/project-snapshot-generator.js
+++ b/snapshot/android/project-snapshot-generator.js
@@ -10,14 +10,14 @@ const {
     createDirectory,
     getJsonFile,
 } = require("./utils");
+const { getPackageJson } = require("../../projectHelpers");
 const {
-    getPackageJson,
+    ANDROID_PROJECT_DIR,
+    ANDROID_APP_PATH,
+    ANDROID_CONFIGURATIONS_PATH,
     getAndroidRuntimeVersion,
-    getAndroidProjectPath,
     getAndroidV8Version,
-    resolveAndroidAppPath,
-    resolveAndroidConfigurationsPath,
-} = require("../../projectHelpers");
+} = require("../../androidProjectHelpers");
 
 const MIN_ANDROID_RUNTIME_VERSION = "3.0.0";
 const VALID_ANDROID_RUNTIME_TAGS = Object.freeze(["next", "rc"]);
@@ -55,8 +55,15 @@ ProjectSnapshotGenerator.prototype.getBuildPath = function () {
 }
 
 ProjectSnapshotGenerator.calculateProjectPath = function (projectRoot) {
-    const projectPath = getAndroidProjectPath({projectRoot});
-    return join(projectRoot, projectPath);
+    return join(projectRoot, ANDROID_PROJECT_DIR);
+}
+
+ProjectSnapshotGenerator.calculateConfigurationsPath = function (projectRoot) {
+    return join(projectRoot, ANDROID_CONFIGURATIONS_PATH);
+}
+
+ProjectSnapshotGenerator.calculateAppPath = function (projectRoot) {
+    return join(projectRoot, ANDROID_APP_PATH);
 }
 
 ProjectSnapshotGenerator.prototype.getProjectPath = function () {
@@ -70,7 +77,7 @@ ProjectSnapshotGenerator.cleanSnapshotArtefacts = function (projectRoot) {
     shelljs.rm("-rf", join(platformPath, "src/main/assets/snapshots"));
 
     // Remove prepared include.gradle configurations
-    const configurationsPath = resolveAndroidConfigurationsPath(projectRoot);
+    const configurationsPath = ProjectSnapshotGenerator.calculateConfigurationsPath(projectRoot);
     shelljs.rm("-rf", join(configurationsPath, SnapshotGenerator.SNAPSHOT_PACKAGE_NANE));
 }
 
@@ -78,8 +85,8 @@ ProjectSnapshotGenerator.installSnapshotArtefacts = function (projectRoot) {
     const buildPath = ProjectSnapshotGenerator.calculateBuildPath(projectRoot);
     const platformPath = ProjectSnapshotGenerator.calculateProjectPath(projectRoot);
 
-    const appPath = resolveAndroidAppPath(projectRoot);
-    const configurationsPath = resolveAndroidConfigurationsPath(projectRoot);
+    const appPath = ProjectSnapshotGenerator.calculateAppPath(projectRoot);
+    const configurationsPath = ProjectSnapshotGenerator.calculateConfigurationsPath(projectRoot);
     const configDestinationPath = join(configurationsPath, SnapshotGenerator.SNAPSHOT_PACKAGE_NANE);
 
     // Remove build folder to make sure that the apk will be fully rebuild
@@ -96,8 +103,7 @@ ProjectSnapshotGenerator.installSnapshotArtefacts = function (projectRoot) {
         // Copy the libs to the specified destination in the platforms folder
         shelljs.mkdir("-p", libsDestinationPath);
         shelljs.cp("-R", join(buildPath, "ndk-build/libs") + "/", libsDestinationPath);
-    }
-    else {
+    } else {
         // useLibs = false
         const blobsSrcPath = join(buildPath, "snapshots/blobs");
         const blobsDestinationPath = resolve(appPath, "../snapshots");


### PR DESCRIPTION
The plugin now works with 4.0+, so the logic for lower versions of the
android runtime is no longer needed.
