### PR TITLE
fix-next: remove extra comma on Object.assign

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,7 +19,7 @@ function buildEnvData($projectData, platform, env) {
     const appResourcesPath = getAppResourcesPathFromProjectData($projectData);
     Object.assign(envData,
         appPath && { appPath },
-        appResourcesPath && { appResourcesPath },
+        appResourcesPath && { appResourcesPath }
     );
 
     return envData;


### PR DESCRIPTION
This can't be parsed with node 6.
