### PR TITLE
fix: bundling of ts apps using linked plugins

### DIFF
--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -73,6 +73,8 @@ module.exports = env => {
             extensions: [".ts", ".js", ".scss", ".css"],
             // Resolve {N} system modules from tns-core-modules
             modules: [
+                resolve(__dirname, "node_modules/tns-core-modules"),
+                resolve(__dirname, "node_modules"),
                 "node_modules/tns-core-modules",
                 "node_modules",
             ],


### PR DESCRIPTION
## What is the current behavior?
If you use a linked plugin with node_modules, the core modules will be included twice in the bundle and the app will crash. 

## What is the new behavior?
If you use a linked plugin with node_modules, the core modules will be included only once from the node_modules in the root folder of the app. 