### PR TITLE
refactor: remove webpack worker loader from templates

### DIFF
--- a/dependencyManager.js
+++ b/dependencyManager.js
@@ -66,7 +66,6 @@ function getRequiredDeps(packageJson) {
         "copy-webpack-plugin": "~4.5.1",
         "raw-loader": "~0.5.1",
         "css-loader": "~0.28.7",
-        "nativescript-worker-loader": "~0.8.1",
         "resolve-url-loader": "~2.3.0",
         "extract-text-webpack-plugin": "~3.0.2",
         "uglifyjs-webpack-plugin": "~1.2.4",

--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -6,7 +6,6 @@ const nativescriptTarget = require("nativescript-dev-webpack/nativescript-target
 const CleanWebpackPlugin = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
-const { NativeScriptWorkerPlugin } = require("nativescript-worker-loader/NativeScriptWorkerPlugin");
 const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 
 module.exports = env => {
@@ -42,7 +41,6 @@ module.exports = env => {
         uglify, // --env.uglify
         report, // --env.report
     } = env;
-    const ngToolsWebpackOptions = { tsConfigPath: join(__dirname, "tsconfig.esm.json") };
 
     const appFullPath = resolve(projectRoot, appPath);
     const appResourcesFullPath = resolve(projectRoot, appResourcesPath);
@@ -179,7 +177,7 @@ module.exports = env => {
                 {
                     test: /.ts$/, use: [
                         "nativescript-dev-webpack/moduleid-compat-loader",
-                        { loader: "@ngtools/webpack", options: ngToolsWebpackOptions },
+                        "@ngtools/webpack",
                     ]
                 },
 
@@ -217,19 +215,16 @@ module.exports = env => {
                 "./vendor",
                 "./bundle",
             ]),
-            // Support for web workers since v3.2
-            new NativeScriptWorkerPlugin(),
             // AngularCompilerPlugin with augmented NativeScript filesystem to handle platform specific resource resolution.
-            new nsWebpack.NativeScriptAngularCompilerPlugin(
-                Object.assign({
+            new nsWebpack.NativeScriptAngularCompilerPlugin({
                     entryModule: resolve(appPath, "app.module#AppModule"),
                     skipCodeGeneration: !aot,
+                    tsConfigPath: join(__dirname, "tsconfig.esm.json"),
                     platformOptions: {
                         platform,
                         platforms,
                     },
-                }, ngToolsWebpackOptions)
-            ),
+            }),
             // Does IPC communication with the {N} CLI to notify events when running in watch mode.
             new nsWebpack.WatchStateLoggerPlugin(),
         ],

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -6,7 +6,6 @@ const nativescriptTarget = require("nativescript-dev-webpack/nativescript-target
 const CleanWebpackPlugin = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
-const { NativeScriptWorkerPlugin } = require("nativescript-worker-loader/NativeScriptWorkerPlugin");
 const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 
 module.exports = env => {
@@ -193,8 +192,6 @@ module.exports = env => {
                 "./vendor",
                 "./bundle",
             ]),
-            // Support for web workers since v3.2
-            new NativeScriptWorkerPlugin(),
             new nsWebpack.PlatformFSPlugin({
                 platform,
                 platforms,

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -6,7 +6,6 @@ const nativescriptTarget = require("nativescript-dev-webpack/nativescript-target
 const CleanWebpackPlugin = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
-const { NativeScriptWorkerPlugin } = require("nativescript-worker-loader/NativeScriptWorkerPlugin");
 const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 
 module.exports = env => {
@@ -203,8 +202,6 @@ module.exports = env => {
                 "./vendor",
                 "./bundle",
             ]),
-            // Support for web workers since v3.2
-            new NativeScriptWorkerPlugin(),
             new nsWebpack.PlatformFSPlugin({
                 platform,
                 platforms,


### PR DESCRIPTION
There are custom setup steps when using worker scripts with webpack, which
cannot be configured within the webpack config only. We'll update the
docs to point to the [worker loader repo](https://github.com/NativeScript/worker-loader).