### PR TITLE
Don't clean the destination app folder when webpack process is already running

### DIFF
--- a/lib/before-cleanApp.js
+++ b/lib/before-cleanApp.js
@@ -1,8 +1,15 @@
 const { cleanSnapshotArtefacts } = require("../snapshot/android/project-snapshot-generator");
 const { isAndroid } = require("../projectHelpers");
+const { getWebpackProcess } = require("./compiler");
 
 module.exports = function (hookArgs) {
-    if (isAndroid(hookArgs.platformInfo.platform)) {
-        cleanSnapshotArtefacts(hookArgs.platformInfo.projectData.projectDir);
+    return (args, originalMethod) => {
+        const webpackProcess = getWebpackProcess();
+        const promise = webpackProcess ? Promise.resolve() : originalMethod(...args);
+        return promise.then(() => {
+            if (isAndroid(hookArgs.platformInfo.platform)) {
+                cleanSnapshotArtefacts(hookArgs.platformInfo.projectData.projectDir);
+             }
+        });
     }
 }


### PR DESCRIPTION
Fixes the case when the user executes the following commands:
tns run android --bundle --release --env.snapshot
tns run android --bundle

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Does not work the following commands:
tns run android --bundle --release --env.snapshot
tns run android --bundle

## What is the new behavior?
Works as expected:
tns run android --bundle --release --env.snapshot
tns run android --bundle