### PR TITLE
fix: register UI modules in NG apps

### DIFF
--- a/bundle-config-loader.js
+++ b/bundle-config-loader.js
@@ -2,6 +2,11 @@ module.exports = function(source) {
     this.cacheable();
     const { angular = false, loadCss = true } = this.query;
 
+    source = `
+        require("tns-core-modules/bundle-entry-points");
+        ${source}
+    `;
+
     if (!angular) {
         source = `
             require("nativescript-dev-webpack/register-modules");

--- a/register-modules.js
+++ b/register-modules.js
@@ -1,4 +1,3 @@
-require("tns-core-modules/bundle-entry-points");
 const context = require.context("~/", true, /(root|page)\.(xml|css|js|ts|scss)$/);
 global.registerWebpackModules(context);
 


### PR DESCRIPTION
This is required, because there may be plugins that use the
tns-core-modules builder.

fixes https://github.com/NativeScript/nativescript-dev-webpack/issues/561