### PR TITLE
fix: schema-utils peer dep warning for webpack 2/3

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "nativescript-hook": "0.2.4",
     "proxy-lib": "0.4.0",
     "request": "2.83.0",
-    "schema-utils": "0.4.3",
+    "schema-utils": "0.4.5",
     "semver": "5.4.1",
     "shelljs": "0.6.0",
     "tapable": "1.0.0",


### PR DESCRIPTION
When tns-creating an app that depends on latest nativescript-dev-webpack you can see the following in the output:
```
npm WARN schema-utils@0.4.3 requires a peer of webpack@^2.0.0 || ^3.0.0 but none is installed. You must install peer dependencies yourself.
```

Based on https://github.com/webpack-contrib/url-loader/issues/122 It seems schema-utils@0.4.5 has the webpack 4 dependency fix.
