### PR TITLE
feat: add setting for plain modules regex

### DIFF
--- a/bundle-config-loader.js
+++ b/bundle-config-loader.js
@@ -1,15 +1,16 @@
-module.exports = function(source) {
+module.exports = function (source) {
     this.cacheable();
-    const { angular = false, loadCss = true } = this.query;
+    const { angular = false, loadCss = true, registerModules = /(root|page)\.(xml|css|js|ts|scss)$/ } = this.query;
 
     source = `
         require("tns-core-modules/bundle-entry-points");
         ${source}
     `;
 
-    if (!angular) {
+    if (!angular && registerModules) {
         source = `
-            require("nativescript-dev-webpack/register-modules");
+            const context = require.context("~/", true, ${registerModules});
+            global.registerWebpackModules(context);
             ${source}
         `;
     }

--- a/register-modules.js
+++ b/register-modules.js
@@ -1,3 +1,0 @@
-const context = require.context("~/", true, /(root|page)\.(xml|css|js|ts|scss)$/);
-global.registerWebpackModules(context);
-


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Currently the regex for loading modules in non-angular apps is hardcoded and causes problems with apps that don't use the correct naming. 

## What is the new behavior?
Adds a `registerModules` option for the `bundle-config-loader` that allows users to specify custom regex to register their modules. Also if needed they can set the new option to `false` completely disabling automatic module registration for non-angular apps. 

Closes #556.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla