### PR TITLE
fix: tell the {N} CLI to ignore the source dir when watching for changes

### DIFF
--- a/lib/before-watchPatterns.js
+++ b/lib/before-watchPatterns.js
@@ -1,8 +1,5 @@
 const { basename } = require("path");
-const {
-    buildEnvData,
-    getCompilationContext,
-} = require("./utils");
+const { getAppPathFromProjectData } = require("../projectHelpers");
 
 module.exports = function (hookArgs) {
     const { liveSyncData } = hookArgs;
@@ -10,27 +7,13 @@ module.exports = function (hookArgs) {
         return;
     }
 
-    const { platforms } = hookArgs;
-    const { env } = liveSyncData;
     return (args, originalMethod) => {
         return originalMethod(...args).then(originalPatterns => {
-            if (!platforms || !platforms.length) {
-                throw new Error("Target platform should be specified!");
-            }
 
-            const compilationContexts = platforms.map(platform =>
-                getContext(hookArgs.projectData, platform, env));
+            const appPath = getAppPathFromProjectData(hookArgs.projectData);
+            const ignorePattern = `!${appPath}`;
 
-            const ignorePatterns = compilationContexts.map(
-                context => `!${context}`
-            );
-
-            return [...originalPatterns, ...ignorePatterns];
+            return [...originalPatterns, ignorePattern];
         });
     };
-}
-
-function getContext(projectData, platform, env) {
-    const fullEnvData = buildEnvData(projectData, platform, env);
-    return getCompilationContext(projectData.projectDir, fullEnvData);
 }

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,11 +1,11 @@
 const utils = require("./utils");
 const { spawn } = require("child_process");
-const { join, resolve: pathResolve } = require("path");
+const { resolve: pathResolve } = require("path");
 const { existsSync } = require("fs");
 const readline = require("readline");
 
 const { messages } = require("../plugins/WatchStateLoggerPlugin");
-const { buildEnvData, getCompilationContext } = require("./utils");
+const { buildEnvData } = require("./utils");
 
 let hasBeenInvoked = false;
 
@@ -84,12 +84,7 @@ exports.runWebpackCompiler = function runWebpackCompiler(config, $projectData, $
                     }
 
                     if (hookArgs.filesToSync && hookArgs.startSyncFilesTimeout) {
-                        const compilationContext = getCompilationContext(projectDir, envData);
-                        hookArgs.filesToSync.push(
-                            ...message.emittedFiles.map(
-                                emittedFile => join(projectDir, compilationContext, emittedFile)
-                            )
-                        );
+                        hookArgs.filesToSync.push(...message.emittedFiles);
                         hookArgs.startSyncFilesTimeout();
                     }
                 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,7 +5,6 @@ const {
     getAppPathFromProjectData,
     getAppResourcesPathFromProjectData,
     getProjectDir,
-    getWebpackConfig,
     isAndroid,
 } = require("../projectHelpers");
 
@@ -25,15 +24,6 @@ function buildEnvData($projectData, platform, env) {
     return envData;
 }
 
-function getCompilationContext(projectDir, env) {
-    const config = getWebpackConfig(projectDir, env);
-    const { context } = config;
-
-    return context ?
-        path.relative(projectDir, context) :
-        ".";
-}
-
 function shouldSnapshot(config) {
     const platformSupportsSnapshot = isAndroid(config.platform);
     const osSupportsSnapshot = os.type() !== "Windows_NT";
@@ -43,6 +33,5 @@ function shouldSnapshot(config) {
 
 module.exports = {
     buildEnvData,
-    getCompilationContext,
     shouldSnapshot
 };

--- a/plugins/WatchStateLoggerPlugin.ts
+++ b/plugins/WatchStateLoggerPlugin.ts
@@ -1,3 +1,4 @@
+import { join } from "path";
 
 export enum messages {
     compilationComplete = "Webpack compilation complete.",
@@ -31,7 +32,8 @@ export class WatchStateLoggerPlugin {
 
             const emittedFiles = Object
                 .keys(compilation.assets)
-                .filter(assetKey => compilation.assets[assetKey].emitted);
+                .filter(assetKey => compilation.assets[assetKey].emitted)
+                .map(file => join(compiler.context, file));
 
             process.send && process.send(messages.compilationComplete, error => null);
             // Send emitted files so they can be LiveSynced if need be

--- a/projectHelpers.js
+++ b/projectHelpers.js
@@ -1,6 +1,5 @@
 const { resolve } = require("path");
 const { readFileSync, writeFileSync } = require("fs");
-const { EOL } = require("os");
 
 const hook = require("nativescript-hook")(__dirname);
 
@@ -26,29 +25,6 @@ const isAngular = ({ projectDir, packageJson } = {}) => {
 
     return packageJson.dependencies && Object.keys(packageJson.dependencies)
         .some(dependency => /^@angular\b/.test(dependency));
-};
-
-const getWebpackConfig = (projectDir, env, configPath = "webpack.config.js") => {
-    const configAbsolutePath = resolve(projectDir, configPath);
-    let config;
-
-    try {
-        config = require(configAbsolutePath);
-    } catch (e) {
-        throw new Error(
-            `Couldn't load webpack config from ${configAbsolutePath}. ` +
-            `Original error:${EOL}${e}`
-        );
-    }
-    if (typeof config === "function") {
-        config = config(env);
-    }
-
-    if (!config) {
-        throw new Error(`Webpack config from ${configAbsolutePath} is empty!`);
-    }
-
-    return config;
 };
 
 const getPackageJson = projectDir => {
@@ -95,7 +71,6 @@ module.exports = {
     getAppResourcesPathFromProjectData,
     getPackageJson,
     getProjectDir,
-    getWebpackConfig,
     isAndroid,
     isIos,
     isAngular,


### PR DESCRIPTION
Stop requiring the webpack config file in the hook, because that may have side effects. Instead tell the {N} CLI watcher to ignore the whole source dir.

fixes #584