### PR TITLE
fix: add @ngtools/webpack to project deps only if @angular-devkit/build-angular is not a dependency

### DIFF
--- a/demo/AngularApp/package.json
+++ b/demo/AngularApp/package.json
@@ -29,7 +29,7 @@
     "zone.js": "^0.8.4"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~0.7.0-beta.1",
+    "@ngtools/webpack": "~6.1.0-rc.0",
     "@angular/compiler-cli": "~6.1.0-beta.1",
     "@types/chai": "^4.0.2",
     "@types/mocha": "^2.2.41",

--- a/dependencyManager.js
+++ b/dependencyManager.js
@@ -56,7 +56,6 @@ function removeObsoleteDeps(packageJson) {
         "nativescript-worker-loader",
         "extract-text-webpack-plugin",
         "uglifyjs-webpack-plugin",
-        "@ngtools/webpack",
         "@angular-devkit/core",
         "resolve-url-loader",
         "awesome-typescript-loader",
@@ -82,12 +81,29 @@ function addDependency(deps, name, version, force) {
 }
 
 function getRequiredDeps(packageJson) {
-    return isAngular({packageJson}) ?
-        {
-            "@angular-devkit/build-angular": "~0.7.0-rc.0",
-            "@angular/compiler-cli": "~6.1.0-beta.1",
-        } :
-        { };
+    if (!isAngular({packageJson})) {
+        return false;
+    }
+
+    const deps = {
+       "@angular/compiler-cli": "~6.1.0-beta.3",
+    };
+
+    if (!dependsOn(packageJson, "@angular-devkit/build-angular")) {
+        deps["@ngtools/webpack"] = "~6.1.0-rc.0";
+    }
+
+    return deps;
+}
+
+
+function dependsOn(packageJson, package) {
+    if (!packageJson) {
+        return false;
+    }
+
+    return packageJson.dependencies.hasOwnProperty(package) ||
+        packageJson.devDependencies.hasOwnProperty(package);
 }
 
 function showHelperMessages({ newDepsAdded, hasOldDeps }) {


### PR DESCRIPTION
Revert to adding @ngtools/webpack instead of
@angular-devkit/build-angular because the later is ~150mb bigger and
slows down the {N} cloud builds.
Add @ngtools/webpack to the project dependencies only if
@angular-devkit/build-angular isn't there already. That's because the
@angular-devkit/build-angular already depends on @ngtools/webpack. This will prevent the
plugin from adding multiple instances of @ngtools/webpack to the project
which would cause the build to fail.

related to #571, #569

BREAKING CHANGES

Not really a breaking change but:
It's a good idea to remove the `@angular-devkit/build-angular` from the
package.json and add `@ngtools/webpack` instead as this will speed up
the build.

fixes #595