### PR TITLE
fix: webpack not working with latest @ngtools rc1

### DIFF
--- a/demo/AngularApp/package.json
+++ b/demo/AngularApp/package.json
@@ -29,7 +29,7 @@
     "zone.js": "^0.8.4"
   },
   "devDependencies": {
-    "@ngtools/webpack": "~6.1.0-rc.0",
+    "@ngtools/webpack": "6.1.0-rc.0",
     "@angular/compiler-cli": "~6.1.0-beta.1",
     "@types/chai": "^4.0.2",
     "@types/mocha": "^2.2.41",

--- a/dependencyManager.js
+++ b/dependencyManager.js
@@ -90,7 +90,7 @@ function getRequiredDeps(packageJson) {
     };
 
     if (!dependsOn(packageJson, "@angular-devkit/build-angular")) {
-        deps["@ngtools/webpack"] = "~6.1.0-rc.0";
+        deps["@ngtools/webpack"] = "6.1.0-rc.0";
     }
 
     return deps;


### PR DESCRIPTION
Temporarily reverting to @ngtools/webpack 6.1.0-rc.0 as we are not working correctly with latest rc1:

Related to https://github.com/NativeScript/nativescript-dev-webpack/issues/607