### PR TITLE
chore: compiler cli & ngtools/webpack to latest rc

### DIFF
--- a/dependencyManager.js
+++ b/dependencyManager.js
@@ -86,11 +86,11 @@ function getRequiredDeps(packageJson) {
     }
 
     const deps = {
-       "@angular/compiler-cli": "~6.1.0-beta.3",
+       "@angular/compiler-cli": "~6.1.0-rc.0",
     };
 
     if (!dependsOn(packageJson, "@angular-devkit/build-angular")) {
-        deps["@ngtools/webpack"] = "6.1.0-rc.0";
+        deps["@ngtools/webpack"] = "~6.1.0-rc.2";
     }
 
     return deps;


### PR DESCRIPTION
We no longer need to hardcode @ngtools/webpack to 6.1.0-rc.0 as https://github.com/NativeScript/nativescript-dev-webpack/issues/607 is fixed with @ngtools/webpack 6.1.0-rc.2