### PR TITLE
fix: define process as undefined

### DIFF
--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -195,6 +195,7 @@ module.exports = env => {
             // Define useful constants like TNS_WEBPACK
             new webpack.DefinePlugin({
                 "global.TNS_WEBPACK": "true",
+                "process": undefined,
             }),
             // Remove all files from the out dir.
             new CleanWebpackPlugin([ `${dist}/**/*` ]),

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -170,6 +170,7 @@ module.exports = env => {
             // Define useful constants like TNS_WEBPACK
             new webpack.DefinePlugin({
                 "global.TNS_WEBPACK": "true",
+                "process": undefined,
             }),
             // Remove all files from the out dir.
             new CleanWebpackPlugin([ `${dist}/**/*` ]),

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -180,6 +180,7 @@ module.exports = env => {
             // Define useful constants like TNS_WEBPACK
             new webpack.DefinePlugin({
                 "global.TNS_WEBPACK": "true",
+                "process": undefined,
             }),
             // Remove all files from the out dir.
             new CleanWebpackPlugin([ `${dist}/**/*` ]),


### PR DESCRIPTION
This will prevent webpack from adding a polyfill for `process` ([`process/browser.js`](https://github.com/defunctzombie/node-process/blob/master/browser.js)) whenever it sees this code: `typeof process`. What will change:

- process will be undefined instead of Object.
- `typeof process === 'undefined'` will return true
- Angular Animations won't assume the app is running in node context
([check](https://github.com/angular/angular/blob/d4ac9698ba7dd829600ca4c8129fcbeae9cb4bed/packages/animations/browser/src/render/shared.ts#L17)) and won't trigger logic which breaks {N} animations.

**Important**
This may break plugins that check if the `process` object is defined.

fixes https://github.com/NativeScript/nativescript-angular/issues/1433