### PR TITLE
chore: update demos inherit from supportlib activity

### DIFF
--- a/demo/AngularApp/app/activity.android.ts
+++ b/demo/AngularApp/app/activity.android.ts
@@ -1,7 +1,7 @@
 import {setActivityCallbacks, AndroidActivityCallbacks} from "ui/frame";
 
 @JavaProxy("org.myApp.MainActivity")
-class Activity extends android.app.Activity {
+class Activity extends android.support.v7.app.AppCompatActivity {
     private _callbacks: AndroidActivityCallbacks;
 
     protected onCreate(savedInstanceState: any): void { // android.os.Bundle

--- a/demo/AngularApp/webpack.config.js
+++ b/demo/AngularApp/webpack.config.js
@@ -41,6 +41,7 @@ module.exports = env => {
         snapshot, // --env.snapshot
         uglify, // --env.uglify
         report, // --env.report
+        sourceMap, // --env.sourceMap
     } = env;
 
     const appFullPath = resolve(projectRoot, appPath);
@@ -98,7 +99,7 @@ module.exports = env => {
             "fs": "empty",
             "__dirname": false,
         },
-        devtool: "none",
+        devtool: sourceMap ? "inline-source-map" : "none",
         optimization: {
             splitChunks: {
                 cacheGroups: {
@@ -196,6 +197,7 @@ module.exports = env => {
             // Define useful constants like TNS_WEBPACK
             new webpack.DefinePlugin({
                 "global.TNS_WEBPACK": "true",
+                "process": undefined,
             }),
             // Remove all files from the out dir.
             new CleanWebpackPlugin([ `${dist}/**/*` ]),
@@ -227,6 +229,7 @@ module.exports = env => {
                 entryModule: resolve(appPath, "app.module#AppModule"),
                 tsConfigPath: join(__dirname, "tsconfig.esm.json"),
                 skipCodeGeneration: !aot,
+                sourceMap: !!sourceMap,
             }),
             // Does IPC communication with the {N} CLI to notify events when running in watch mode.
             new nsWebpack.WatchStateLoggerPlugin(),

--- a/demo/JavaScriptApp/app/activity.android.js
+++ b/demo/JavaScriptApp/app/activity.android.js
@@ -1,7 +1,7 @@
 const frame = require("ui/frame");
 
-const superProto = android.app.Activity.prototype;
-android.app.Activity.extend("org.myApp.MainActivity", {
+const superProto = android.support.v7.app.AppCompatActivity.prototype;
+android.support.v7.app.AppCompatActivity.extend("org.myApp.MainActivity", {
     onCreate: function(savedInstanceState) {
         if(!this._callbacks) {
             frame.setActivityCallbacks(this);

--- a/demo/JavaScriptApp/webpack.config.js
+++ b/demo/JavaScriptApp/webpack.config.js
@@ -40,6 +40,7 @@ module.exports = env => {
         snapshot, // --env.snapshot
         uglify, // --env.uglify
         report, // --env.report
+        sourceMap, // --env.sourceMap
     } = env;
 
     const appFullPath = resolve(projectRoot, appPath);
@@ -95,7 +96,7 @@ module.exports = env => {
             "fs": "empty",
             "__dirname": false,
         },
-        devtool: "none",
+        devtool: sourceMap ? "inline-source-map" : "none",
         optimization:  {
             splitChunks: {
                 cacheGroups: {
@@ -171,6 +172,7 @@ module.exports = env => {
             // Define useful constants like TNS_WEBPACK
             new webpack.DefinePlugin({
                 "global.TNS_WEBPACK": "true",
+                "process": undefined,
             }),
             // Remove all files from the out dir.
             new CleanWebpackPlugin([ `${dist}/**/*` ]),

--- a/demo/TypeScriptApp/app/activity.android.ts
+++ b/demo/TypeScriptApp/app/activity.android.ts
@@ -1,7 +1,7 @@
 import {setActivityCallbacks, AndroidActivityCallbacks} from "ui/frame";
 
 @JavaProxy("org.myApp.MainActivity")
-class Activity extends android.app.Activity {
+class Activity extends android.support.v7.app.AppCompatActivity {
     private _callbacks: AndroidActivityCallbacks;
 
     protected onCreate(savedInstanceState: any): void { // android.os.Bundle

--- a/demo/TypeScriptApp/webpack.config.js
+++ b/demo/TypeScriptApp/webpack.config.js
@@ -40,6 +40,7 @@ module.exports = env => {
         snapshot, // --env.snapshot
         uglify, // --env.uglify
         report, // --env.report
+        sourceMap, // --env.sourceMap
     } = env;
 
     const appFullPath = resolve(projectRoot, appPath);
@@ -97,7 +98,7 @@ module.exports = env => {
             "fs": "empty",
             "__dirname": false,
         },
-        devtool: "none",
+        devtool: sourceMap ? "inline-source-map" : "none",
         optimization:  {
             splitChunks: {
                 cacheGroups: {
@@ -181,6 +182,7 @@ module.exports = env => {
             // Define useful constants like TNS_WEBPACK
             new webpack.DefinePlugin({
                 "global.TNS_WEBPACK": "true",
+                "process": undefined,
             }),
             // Remove all files from the out dir.
             new CleanWebpackPlugin([ `${dist}/**/*` ]),


### PR DESCRIPTION
With https://github.com/NativeScript/NativeScript/pull/6129 custom Android activities should inherit from `android.support.v7.app.AppCompatActivity` vs `android.app.Activity` previously.

@NickIliev @tsonevn https://github.com/NativeScript/docs/pull/1301