### PR TITLE
refactor(angular): provide mainPath instead of entryModule to ng compiler plugin

### DIFF
--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -224,7 +224,7 @@ module.exports = env => {
 
             new AngularCompilerPlugin({
                 hostReplacementPaths: nsWebpack.getResolver([platform, "tns"]),
-                entryModule: resolve(appPath, "app.module#AppModule"),
+                mainPath: resolve(appPath, "main.ts"),
                 tsConfigPath: join(__dirname, "tsconfig.esm.json"),
                 skipCodeGeneration: !aot,
                 sourceMap: !!sourceMap,


### PR DESCRIPTION
The entryModule path can differ depending on what kind of project you're
using - mobile or web+mobile. While the best solution is to get the
mainPath from angular.json, not all {N} projects have that file. We'll
stick to the standard for web and web+mobile location - `appPath/main.ts`.

**Note** - We'll have to update {N} schematics to reflect this change.