### PR TITLE
Sync only hmr updates without bundle files

### DIFF
--- a/bundle-config-loader.js
+++ b/bundle-config-loader.js
@@ -10,11 +10,16 @@ module.exports = function (source) {
     if (!angular && registerModules) {
         const hmr = `
             if (module.hot) {
+                const fileSystemModule = require("tns-core-modules/file-system");
+                const applicationFiles = fileSystemModule.knownFolders.currentApp();
+
                 global.__hmrLivesyncBackup = global.__onLiveSync;
                 global.__onLiveSync = function () {
                     console.log("LiveSyncing...");
-                    require("nativescript-dev-webpack/hot")("", {});
+                    require("nativescript-dev-webpack/hot")(__webpack_require__.h(), (fileName) => applicationFiles.getFile(fileName));
                 };
+                global.__hmrInitialSync = true; // needed to determine if we are performing initial sync
+                global.__onLiveSync();
             }
         `;
 

--- a/hot-loader-helper.js
+++ b/hot-loader-helper.js
@@ -1,11 +1,11 @@
-module.exports.reload = `
+module.exports.reload = function(type) { return `
     if (module.hot) {
         module.hot.accept();
         module.hot.dispose(() => {
             setTimeout(() => {
                 global.__hmrLivesyncBackup();
-            });
+            }, ${type === 'style' ? "global.__hmrInitialSync ? 1000 : 0" : 0});
         })
     }
-`;
-
+`};
+// we need to add a timeout of 1000 if we have a css change, otherwise the app crashes on initial hmr sync

--- a/markup-hot-loader.js
+++ b/markup-hot-loader.js
@@ -1,5 +1,5 @@
 const { reload } = require("./hot-loader-helper");
 
 module.exports = function (source) {
-    return `${source};${reload}`;
+    return `${source};${reload('markup')}`;
 };

--- a/page-hot-loader.js
+++ b/page-hot-loader.js
@@ -1,5 +1,5 @@
 const { reload } = require("./hot-loader-helper");
 
 module.exports = function (source) {
-    return `${source};${reload}`;
+    return `${source};${reload('page')}`;
 };

--- a/plugins/WatchStateLoggerPlugin.ts
+++ b/plugins/WatchStateLoggerPlugin.ts
@@ -32,13 +32,15 @@ export class WatchStateLoggerPlugin {
                 console.log(messages.compilationComplete);
             }
 
-            const emittedFiles = Object
+            let emittedFiles = Object
                 .keys(compilation.assets)
                 .filter(assetKey => compilation.assets[assetKey].emitted);
 
             if (compilation.errors.length > 0) {
                 WatchStateLoggerPlugin.rewriteHotUpdateChunk(compiler, compilation, emittedFiles);
             }
+
+            emittedFiles = WatchStateLoggerPlugin.getUpdatedEmittedFiles(emittedFiles);
 
             // provide fake paths to the {N} CLI - relative to the 'app' folder
             // in order to trigger the livesync process
@@ -88,6 +90,19 @@ export class WatchStateLoggerPlugin {
             endIndex--;
         }
         return content.substring(startIndex, endIndex);
+    }
+
+    /**
+     * Checks if there's a file in the following pattern 5e0326f3bb50f9f26cf0.hot-update.json
+     * if yes this is a HMR update and remove all bundle files as we don't need them to be synced,
+     * but only the update chunks
+     */
+    static getUpdatedEmittedFiles(emittedFiles) {
+        if(emittedFiles.some(x => x.endsWith('.hot-update.json'))) {
+            return emittedFiles.filter(x => x.indexOf('.hot-update.') > 0);
+        } else {
+            return emittedFiles;
+        }
     }
 
     /**

--- a/style-hot-loader.js
+++ b/style-hot-loader.js
@@ -1,5 +1,5 @@
 const { reload } = require("./hot-loader-helper");
 
 module.exports = function (source) {
-    return `${source};${reload}`;
+    return `${source};${reload('style')}`;
 };


### PR DESCRIPTION
* Do not sync bundle files
* Relay all the hmr update on application start directly on the device
* Distinguish page/markup/style updates in the hot-loader-helper