### PR TITLE
fix: read the hmr option from the preview command

### DIFF
--- a/lib/before-preview-sync.js
+++ b/lib/before-preview-sync.js
@@ -1,10 +1,11 @@
 const { runWebpackCompiler } = require("./compiler");
 
-module.exports = function($logger, $liveSyncService, hookArgs) {
+module.exports = function($logger, $liveSyncService, $options, hookArgs) {
 	const { config } = hookArgs;
 	const bundle = config && config.appFilesUpdaterOptions && config.appFilesUpdaterOptions.bundle;
 	if (bundle) {
 		const env = config.env || {};
+		env.hmr = !!$options.hmr;
 		const platform = config.platform;
 		const release = config && config.appFilesUpdaterOptions && config.appFilesUpdaterOptions.release;
 		const compilerConfig = {


### PR DESCRIPTION
Add support for `tns preview --bundle --hmr`