### PR TITLE
chore:  stop webpack compiler when ctrl+c is pressed while executing `tns preview --bundle` command

### DIFF
--- a/lib/before-watch.js
+++ b/lib/before-watch.js
@@ -12,6 +12,10 @@ module.exports = function ($logger, $liveSyncService, $options, $devicesService,
                         stopWebpackCompiler(platform);
                     }
                 });
+
+                process.on("exit", () => {
+                    stopWebpackCompiler();
+                });
             });
 
             const platforms = hookArgs.config.platforms;


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Webpack process does not stop when ctrl+c is pressed while executing tns preview --bundle command

## What is the new behavior?
Webpack process stops when ctrl+c is pressed while executing tns preview --bundle command

Rel to: https://github.com/NativeScript/nativescript-cli/pull/3897


[CLA]: http://www.nativescript.org/cla