### PR TITLE
fix: cache/parallel should be outside uglifyOptions

### DIFF
--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -129,9 +129,9 @@ module.exports = env => {
             minimize: !!uglify,
             minimizer: [
                 new UglifyJsPlugin({
+                    parallel: true,
+                    cache: true,
                     uglifyOptions: {
-                        parallel: true,
-                        cache: true,
                         output: {
                             comments: false,
                         },

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -119,9 +119,9 @@ module.exports = env => {
             minimize: !!uglify,
             minimizer: [
                 new UglifyJsPlugin({
+                    parallel: true,
+                    cache: true,
                     uglifyOptions: {
-                        parallel: true,
-                        cache: true,
                         output: {
                             comments: false,
                         },

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -121,9 +121,9 @@ module.exports = env => {
             minimize: !!uglify,
             minimizer: [
                 new UglifyJsPlugin({
+                    parallel: true,
+                    cache: true,
                     uglifyOptions: {
-                        parallel: true,
-                        cache: true,
                         output: {
                             comments: false,
                         },

--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -127,9 +127,9 @@ module.exports = env => {
             minimize: Boolean(production),
             minimizer: [
                 new UglifyJsPlugin({
+                    parallel: true,
+                    cache: true,
                     uglifyOptions: {
-                        parallel: true,
-                        cache: true,
                         output: {
                             comments: false,
                         },


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
`cache`/`parallel` are inside `uglifyOptions`.

## What is the new behavior?
`cache`/`parallel` are outside `uglifyOptions` per the documentation.
https://webpack.js.org/plugins/uglifyjs-webpack-plugin/#cache
https://webpack.js.org/plugins/uglifyjs-webpack-plugin/#parallel
https://webpack.js.org/plugins/uglifyjs-webpack-plugin/#uglifyoptions

BREAKING CHANGES:
None.

Migration steps:
Existing users will need to update their configs.


[CLA]: http://www.nativescript.org/cla