### PR TITLE
fix: attach to process's exit event on correct place

### DIFF
--- a/lib/before-watch.js
+++ b/lib/before-watch.js
@@ -12,10 +12,10 @@ module.exports = function ($logger, $liveSyncService, $devicesService, hookArgs)
                         stopWebpackCompiler(platform);
                     }
                 });
+            });
 
-                process.on("exit", () => {
-                    stopWebpackCompiler();
-                });
+            process.on("exit", () => {
+                stopWebpackCompiler();
             });
 
             const platforms = hookArgs.config.platforms;


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
webpack process is not stopped when ctrl+c is pressed while executing `tns preview --bundle`

## What is the new behavior?
webpack process is stopped when ctrl+c is pressed while executing `tns preview --bundle`