### PR TITLE
fix: don't call twice `startSyncFilesTimeout` method

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -80,13 +80,11 @@ exports.runWebpackCompiler = function runWebpackCompiler(config, $projectData, $
                         return;
                     }
 
-                    if (hookArgs.filesToSync && hookArgs.startSyncFilesTimeout) {
-                        hookArgs.filesToSync.push(...message.emittedFiles);
-                        hookArgs.startSyncFilesTimeout(platform);
-                    }
-
                     if (hookArgs.filesToSyncMap && hookArgs.startSyncFilesTimeout) {
                         hookArgs.filesToSyncMap[platform] = message.emittedFiles;
+                        hookArgs.startSyncFilesTimeout(platform);
+                    } else if (hookArgs.filesToSync && hookArgs.startSyncFilesTimeout) {
+                        hookArgs.filesToSync.push(...message.emittedFiles);
                         hookArgs.startSyncFilesTimeout(platform);
                     }
                 }


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
`startSyncFilesTimeout` is called twice with next versions of {N} CLI and `nativescript-dev-webpack` plugin

## What is the new behavior?
`startSyncFilesTimeout` is called only once with next versions of {N} CLI and `nativescript-dev-webpack` plugin