### PR TITLE
feat: send data for fallback if hmr apply fails

### DIFF
--- a/hot.js
+++ b/hot.js
@@ -91,17 +91,16 @@ function check(options) {
                     result(modules, appliedModules);
 
                     if (upToDate()) {
+                        //Do not modify message - CLI depends on this exact content to determine hmr operation status.
                         log.info(`Successfully applied update with hmr hash ${currentHash}. App is up to date.`);
                     }
                 })
                 .catch((err) => {
                     const status = module.hot.status();
                     if (['abort', 'fail'].indexOf(status) >= 0) {
+                        //Do not modify message - CLI depends on this exact content to determine hmr operation status.
                         log.warn(`Cannot apply update with hmr hash ${currentHash}.`);
                         log.warn(err.stack || err.message);
-                        if (options.reload) {
-                            window.location.reload();
-                        }
                     } else {
                         log.warn(`Update failed: ${err.stack || err.message}`);
                     }
@@ -130,6 +129,7 @@ function update(latestHash, options) {
         const status = module.hot.status();
 
         if (status === 'idle') {
+            //Do not modify message - CLI depends on this exact content to determine hmr operation status.
             log.info(`Checking for updates to the bundle with hmr hash ${currentHash}.`);
             check(options);
         } else if (['abort', 'fail'].indexOf(status) >= 0) {

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -5,7 +5,7 @@ const { existsSync } = require("fs");
 const readline = require("readline");
 
 const { messages } = require("../plugins/WatchStateLoggerPlugin");
-const { buildEnvData, debuggingEnabled } = require("./utils");
+const { buildEnvData, debuggingEnabled, getUpdatedEmittedFiles } = require("./utils");
 
 let hasBeenInvoked = false;
 
@@ -80,11 +80,18 @@ exports.runWebpackCompiler = function runWebpackCompiler(config, $projectData, $
                         return;
                     }
 
+                    const result = getUpdatedEmittedFiles(message.emittedFiles);
+
+                    if (hookArgs.hmrData && hookArgs.hmrData.fallbackFiles) {
+                        hookArgs.hmrData.fallbackFiles[platform] = result.fallbackFiles;
+                        hookArgs.hmrData.hash = result.hash || "";
+                    }
+
                     if (hookArgs.filesToSyncMap && hookArgs.startSyncFilesTimeout) {
-                        hookArgs.filesToSyncMap[platform] = message.emittedFiles;
+                        hookArgs.filesToSyncMap[platform] = result.emittedFiles;
                         hookArgs.startSyncFilesTimeout(platform);
                     } else if (hookArgs.filesToSync && hookArgs.startSyncFilesTimeout) {
-                        hookArgs.filesToSync.push(...message.emittedFiles);
+                        hookArgs.filesToSync.push(...result.emittedFiles);
                         hookArgs.startSyncFilesTimeout(platform);
                     }
                 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,6 +29,46 @@ function buildEnvData($projectData, platform, env) {
     return envData;
 }
 
+/**
+ * Checks if there's a file in the following pattern 5e0326f3bb50f9f26cf0.hot-update.json
+ * if yes this is a HMR update and remove all bundle files as we don't need them to be synced,
+ * but only the update chunks
+ */
+function getUpdatedEmittedFiles(emittedFiles) {
+    let fallbackFiles = [];
+    let hotHash;
+    if (emittedFiles.some(x => x.endsWith('.hot-update.json'))) {
+        let result = emittedFiles.slice();
+        const hotUpdateScripts = emittedFiles.filter(x => x.endsWith('.hot-update.js'));
+        hotUpdateScripts.forEach(hotUpdateScript => {
+            const { name, hash } = parseHotUpdateChunkName(hotUpdateScript);
+            hotHash = hash;
+            // remove bundle/vendor.js files if there's a bundle.XXX.hot-update.js or vendor.XXX.hot-update.js
+            result = result.filter(file => file !== `${name}.js`);
+        });
+        //if applying of hot update fails, we must fallback to the full files
+        fallbackFiles = emittedFiles.filter(file => result.indexOf(file) === -1);
+        return { emittedFiles: result, fallbackFiles, hash: hotHash };
+    }
+    else {
+        return { emittedFiles, fallbackFiles };
+    }
+}
+
+/**
+ * Parse the filename of the hot update chunk.
+ * @param name bundle.deccb264c01d6d42416c.hot-update.js
+ * @returns { name: string, hash: string } { name: 'bundle', hash: 'deccb264c01d6d42416c' }
+ */
+function parseHotUpdateChunkName(name) {
+    const matcher = /^(.+)\.(.+)\.hot-update/gm;
+    const matches = matcher.exec(name);
+    return {
+        name: matches[1] || "",
+        hash: matches[2] || "",
+    };
+}
+
 function shouldSnapshot(config) {
     const platformSupportsSnapshot = isAndroid(config.platform);
     const osSupportsSnapshot = os.type() !== "Windows_NT";
@@ -39,5 +79,7 @@ function shouldSnapshot(config) {
 module.exports = {
     buildEnvData,
     debuggingEnabled,
-    shouldSnapshot
+    shouldSnapshot,
+    getUpdatedEmittedFiles,
+    parseHotUpdateChunkName
 };


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently there is no indication in the log, which hmr patch is applied and in hook args there is no data about the hmr hash and the files that should be synced if the hmr operation fails.

## What is the new behavior?
<!-- Describe the changes. -->
There is a hash added for start, success or fail of the hmr operation and there are properties in the `hookArgs` which are populated with information about current hmr operation.


Fixes/Implements/Closes [#3892](https://github.com/NativeScript/nativescript-cli/issues/3892).

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla