### PR TITLE
fix: send hash per platform when more than one webpacks are stated

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -82,9 +82,11 @@ exports.runWebpackCompiler = function runWebpackCompiler(config, $projectData, $
 
                     const result = getUpdatedEmittedFiles(message.emittedFiles);
 
-                    if (hookArgs.hmrData && hookArgs.hmrData.fallbackFiles) {
-                        hookArgs.hmrData.fallbackFiles[platform] = result.fallbackFiles;
-                        hookArgs.hmrData.hash = result.hash || "";
+                    if (hookArgs.hmrData) {
+                        hookArgs.hmrData[platform] = {
+                            hash: result.hash || "",
+                            fallbackFiles: result.fallbackFiles
+                        };
                     }
 
                     if (hookArgs.filesToSyncMap && hookArgs.startSyncFilesTimeout) {


### PR DESCRIPTION
Hmr hash is not correct when more than one webpacks are started. So send hash per platform in order to ensure {N} CLI will receive the correct hash.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
{N} CLI does not receive correct file's hash when 2 webpacks are started.

## What is the new behavior?
{N} CLI receives the correct file's hash when 2 webpacks are started.