### PR TITLE
fix: don't throw MaxListenersExceeded error when more than 11 processes are started from sidekick

### DIFF
--- a/lib/after-watch.js
+++ b/lib/after-watch.js
@@ -1,6 +1,9 @@
 const { stopWebpackCompiler } = require('./compiler');
+const { removeListener } = require("./utils");
 
-module.exports = function($logger) {
+module.exports = function($logger, $liveSyncService) {
     $logger.info("Stopping webpack watch");
     stopWebpackCompiler();
+    removeListener($liveSyncService, "liveSyncStopped");
+    removeListener(process, "exit");
 }

--- a/lib/before-watch.js
+++ b/lib/before-watch.js
@@ -1,10 +1,11 @@
 const { getWebpackProcesses, runWebpackCompiler, stopWebpackCompiler } = require("./compiler");
+const { addListener } = require("./utils");
 
 module.exports = function ($logger, $liveSyncService, $devicesService, hookArgs) {
     if (hookArgs.config) {
         const appFilesUpdaterOptions = hookArgs.config.appFilesUpdaterOptions;
         if (appFilesUpdaterOptions.bundle) {
-            $liveSyncService.on("liveSyncStopped", data => {
+            addListener($liveSyncService, "liveSyncStopped", () => {
                 const webpackProcesses = getWebpackProcesses();
                 Object.keys(webpackProcesses).forEach(platform => {
                     const devices = $devicesService.getDevicesForPlatform(platform);
@@ -13,10 +14,7 @@ module.exports = function ($logger, $liveSyncService, $devicesService, hookArgs)
                     }
                 });
             });
-
-            process.on("exit", () => {
-                stopWebpackCompiler();
-            });
+            addListener(process, "exit", stopWebpackCompiler);
 
             const platforms = hookArgs.config.platforms;
             return Promise.all(platforms.map(platform => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,6 +8,8 @@ const {
     isAndroid,
 } = require("../projectHelpers");
 
+const eventHandlers = {};
+
 function debuggingEnabled(liveSyncService, projectDir) {
     const deviceDescriptors = liveSyncService.getLiveSyncDeviceDescriptors(projectDir);
     return deviceDescriptors.some(device => device.debugggingEnabled);
@@ -76,10 +78,26 @@ function shouldSnapshot(config) {
     return config.bundle && config.release && platformSupportsSnapshot && osSupportsSnapshot;
 }
 
+function addListener(eventEmitter, name, handler) {
+    if (!eventHandlers[name]) {
+        eventEmitter.on(name, handler);
+        eventHandlers[name] = handler;
+    }
+}
+
+function removeListener(eventEmitter, name) {
+    if (eventHandlers[name]) {
+        eventEmitter.removeListener(name, eventHandlers[name]);
+        delete eventHandlers[name];
+    }
+}
+
 module.exports = {
     buildEnvData,
     debuggingEnabled,
     shouldSnapshot,
     getUpdatedEmittedFiles,
-    parseHotUpdateChunkName
+    parseHotUpdateChunkName,
+    addListener,
+    removeListener
 };


### PR DESCRIPTION
In case when the user runs 11 apps from sidekick (or only 2 apps changing them 6 times), 
```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 exit listeners added. Use emitter.setMaxListeners() to increase limit
```
error is thrown. The problem occurs because we attach every time on `process.exit` and `liveSyncStopped` events. So this PR fixes this behavior as ensures only one listener is added for each event.
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 exit listeners added. Use emitter.setMaxListeners() to increase limit
```
error is thrown when the user runs 11 apps from sidekick (or only 2 apps changing them 6 times)

## What is the new behavior?
No error is thrown when the user runs 11 apps from sidekick (or only 2 apps changing them 6 times)
