### PR TITLE
fix: update the version of `request` (#694)

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "minimatch": "3.0.4",
     "nativescript-hook": "0.2.4",
     "proxy-lib": "0.4.0",
-    "request": "2.83.0",
+    "request": "2.88.0",
     "schema-utils": "0.4.5",
     "semver": "5.4.1",
     "shelljs": "0.6.0",


### PR DESCRIPTION
Due to security vulnerabilities in one of its dependencies
(`cryptiles`).