### PR TITLE
feat(HMR): expose context

### DIFF
--- a/bundle-config-loader.js
+++ b/bundle-config-loader.js
@@ -19,12 +19,12 @@ module.exports = function (source) {
                     require("nativescript-dev-webpack/hot")(__webpack_require__.h(), (fileName) => applicationFiles.getFile(fileName));
                 };
 
-                global.__hmrRefresh = function(type) {
+                global.__hmrRefresh = function({ type, module }) {
                     global.__hmrNeedReload = true;
                     setTimeout(() => {
                         if(global.__hmrNeedReload) {
                             global.__hmrNeedReload = false;
-                            global.__hmrLivesyncBackup();
+                            global.__hmrLivesyncBackup({ type, module });
                         }
                     });
                 }
@@ -45,9 +45,9 @@ module.exports = function (source) {
     if (loadCss) {
         source = `
             require("${
-                angular ?
-                    'nativescript-dev-webpack/load-application-css-angular' :
-                    'nativescript-dev-webpack/load-application-css-regular'
+            angular ?
+                'nativescript-dev-webpack/load-application-css-angular' :
+                'nativescript-dev-webpack/load-application-css-regular'
             }")();
             ${source}
         `;

--- a/hot-loader-helper.js
+++ b/hot-loader-helper.js
@@ -1,9 +1,9 @@
-module.exports.reload = function(type) { return `
+module.exports.reload = function ({ type, module }) {
+    return `
     if (module.hot) {
         module.hot.accept();
         module.hot.dispose(() => {
-            global.__hmrRefresh('${type}');
+            global.__hmrRefresh({ type: '${type}', module: '${module}' });
         })
     }
 `};
-

--- a/markup-hot-loader.js
+++ b/markup-hot-loader.js
@@ -1,5 +1,7 @@
 const { reload } = require("./hot-loader-helper");
 
 module.exports = function (source) {
-    return `${source};${reload('markup')}`;
+    const typeMarkup = "markup";
+    const modulePath = this.resourcePath.replace(this.context, ".");
+    return `${source};${reload({ type: typeMarkup, module: modulePath })}`;
 };

--- a/script-hot-loader.js
+++ b/script-hot-loader.js
@@ -1,5 +1,7 @@
 const { reload } = require("./hot-loader-helper");
 
 module.exports = function (source) {
-    return `${source};${reload('script')}`;
+    const typeScript = "script";
+    const modulePath = this.resourcePath.replace(this.context, ".");
+    return `${source};${reload({ type: typeScript, module: modulePath })}`;
 };

--- a/style-hot-loader.js
+++ b/style-hot-loader.js
@@ -1,5 +1,7 @@
 const { reload } = require("./hot-loader-helper");
 
 module.exports = function (source) {
-    return `${source};${reload('style')}`;
+    const typeStyle = "style";
+    const modulePath = this.resourcePath.replace(this.context, ".");
+    return `${source};${reload({ type: typeStyle, module: modulePath })}`;
 };


### PR DESCRIPTION
The context consists of an object with `type` and `module` properties:
- `type` could be `markup`, `script` or `style`
- `module` is the relative path to the module

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, `global.__hmrRefresh()` function accepts a`type` parameter which doesn't pass to `global.__onLiveSync` function.

## What is the new behavior?
<!-- Describe the changes. -->

The new behavior changes `global.__hmrRefresh()` function to accept a context `{ type, module }` object and pass it to `global.__onLiveSync` function.

In this way, the cross-platform modules (`tns-core-modules`) could handle different scenarios based on the context.

Relates to https://github.com/NativeScript/NativeScript/pull/6665.
Implements a part of https://github.com/NativeScript/NativeScript/issues/6645.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla