### PR TITLE
fix: project's package.json indentation is not persisted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ jasmine-config/reporter.js.map
 
 hooks
 .DS_Store
+
+!projectHelpers.spec.js

--- a/jasmine-config/jasmine.json
+++ b/jasmine-config/jasmine.json
@@ -1,7 +1,8 @@
 {
   "spec_dir": ".",
   "spec_files": [
-    "./!(node_modules)/**/*.spec.js"
+	"./!(node_modules)/**/*.spec.js",
+	"./*.spec.js"
   ],
   "helpers": [
     "jasmine-config/**/*.js"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "scripts": {
     "postinstall": "node postinstall.js",
     "postpack": "rm -rf node_modules",
-    "prepare": "tsc",
+    "prepare": "tsc && npm run jasmine",
     "test": "npm run prepare && npm run jasmine",
     "jasmine": "jasmine --config=jasmine-config/jasmine.json",
     "version": "rm package-lock.json && conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md"

--- a/projectHelpers.js
+++ b/projectHelpers.js
@@ -1,5 +1,5 @@
 const { resolve } = require("path");
-const { readFileSync, writeFileSync } = require("fs");
+const fs = require("fs");
 
 const hook = require("nativescript-hook")(__dirname);
 
@@ -38,13 +38,26 @@ const isVue = ({ projectDir, packageJson } = {}) => {
 
 const getPackageJson = projectDir => {
     const packageJsonPath = getPackageJsonPath(projectDir);
-    return JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    return JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
 };
 
 const writePackageJson = (content, projectDir) => {
     const packageJsonPath = getPackageJsonPath(projectDir);
-    writeFileSync(packageJsonPath, JSON.stringify(content, null, 2))
+    const currentJsonContent = fs.readFileSync(packageJsonPath);
+    const indentation = getIndentationCharacter(currentJsonContent);
+    const stringifiedContent = JSON.stringify(content, null, indentation);
+    const currentPackageJsonContent = JSON.parse(currentJsonContent);
+
+    if (JSON.stringify(currentPackageJsonContent, null, indentation) !== stringifiedContent) {
+        fs.writeFileSync(packageJsonPath, stringifiedContent)
+    }
 }
+
+const getIndentationCharacter = (jsonContent) => {
+    const matches = jsonContent.match(/{\r*\n*(\W*)"/m);
+    return matches && matches[1];
+}
+
 const getProjectDir = hook.findProjectDir;
 
 const getPackageJsonPath = projectDir => resolve(projectDir, "package.json");
@@ -96,5 +109,6 @@ module.exports = {
     isVue,
     isTypeScript,
     writePackageJson,
-    convertSlashesInPath
+    convertSlashesInPath,
+    getIndentationCharacter
 };

--- a/projectHelpers.js
+++ b/projectHelpers.js
@@ -54,7 +54,7 @@ const writePackageJson = (content, projectDir) => {
 }
 
 const getIndentationCharacter = (jsonContent) => {
-    const matches = jsonContent.match(/{\r*\n*(\W*)"/m);
+    const matches = jsonContent && jsonContent.toString().match(/{\r*\n*(\W*)"/m);
     return matches && matches[1];
 }
 

--- a/projectHelpers.spec.js
+++ b/projectHelpers.spec.js
@@ -1,0 +1,105 @@
+const { getIndentationCharacter, writePackageJson } = require("./projectHelpers");
+const fs = require("fs");
+
+describe('projectHelpers', () => {
+    const originalReadFileSync = fs.readFileSync;
+    const originalWriteFileSync = fs.writeFileSync;
+    const tab = "\t";
+    const multipleSpaces = "        ";
+    const twoSpaces = "  ";
+
+    afterEach(() => {
+        fs.readFileSync = originalReadFileSync;
+        fs.writeFileSync = originalWriteFileSync;
+    });
+
+    describe('getIndentationCharacter', () => {
+        [
+            {
+                testName: 'returns two spaces when file starts with two spaces',
+                input: `{${twoSpaces}"abc": "1"${twoSpaces}}`,
+                expectedResult: twoSpaces
+            },
+            {
+                testName: 'returns empty string when file starts without any indentation',
+                input: `{"abc": "1"}`,
+                expectedResult: ''
+            },
+            {
+                testName: 'returns tab when file starts with tab',
+                input: `{${tab}"abc": "1"${tab}}`,
+                expectedResult: tab
+            },
+            {
+                testName: 'returns two spaces when file starts with two spaces and new line before them',
+                input: `{\n${twoSpaces}"abc": "1"\n}`,
+                expectedResult: twoSpaces
+            },
+            {
+                testName: 'returns tab when file starts with tab and new line before them',
+                input: `{\n${tab}"abc": "1"\n}`,
+                expectedResult: tab
+            },
+            {
+                testName: 'returns multiple spaces when file starts with multiple spaces and new line before them',
+                input: `{\n${multipleSpaces}"abc": "1"\n}`,
+                expectedResult: multipleSpaces
+            }
+        ].forEach(({ testName, input, expectedResult }) => {
+            it(testName, () => {
+                expect(getIndentationCharacter(input)).toEqual(expectedResult);
+            });
+        });
+    });
+
+    describe('writePackageJson', () => {
+        const mockFileSystemApi = () => {
+            const data = {
+                isWriteFileSyncCalled: false
+            };
+
+            fs.readFileSync = (p) => {
+                return JSON.stringify({ a: 1 });
+            };
+
+            fs.writeFileSync = (p, c) => {
+                data.isWriteFileSyncCalled = true;
+            };
+
+            return data;
+        };
+
+        it('does not write package.json when content has not changed', () => {
+            const data = mockFileSystemApi();
+            writePackageJson({ a: 1 }, "projDir");
+            expect(data.isWriteFileSyncCalled).toBe(false);
+        });
+
+        it('writes content, when the new one is different from the current one', () => {
+            const data = mockFileSystemApi();
+            writePackageJson({ b: 2 }, "projDir");
+            expect(data.isWriteFileSyncCalled).toBe(true);
+        });
+
+        it('keeps indentation of the package.json when rewriting it', () => {
+            let currentIndentSymbol = tab;
+            fs.readFileSync = (p) => {
+                return JSON.stringify({ a: 1 }, null, currentIndentSymbol);
+            };
+
+            let writtenContent = null;
+            fs.writeFileSync = (p, c) => {
+                writtenContent = c;
+            };
+
+            // Ensure tab indentation is persisted
+            writePackageJson({ b: 2 }, "projDir");
+            expect(writtenContent).toBe(`{\n${tab}"b": 2\n}`);
+
+            // Ensure spaces indentation is persisted
+            currentIndentSymbol = multipleSpaces;
+            writePackageJson({ b: 2 }, "projDir");
+            expect(writtenContent).toBe(`{\n${multipleSpaces}"b": 2\n}`);
+        });
+    });
+});

--- a/projectHelpers.spec.js
+++ b/projectHelpers.spec.js
@@ -19,6 +19,11 @@ describe('projectHelpers', () => {
                 testName: 'returns two spaces when file starts with two spaces',
                 input: `{${twoSpaces}"abc": "1"${twoSpaces}}`,
                 expectedResult: twoSpaces
+			},
+			{
+                testName: 'returns two spaces when file starts with two spaces and binary content is passed',
+                input: Buffer.from(`{${twoSpaces}"abc": "1"${twoSpaces}}`),
+                expectedResult: twoSpaces
             },
             {
                 testName: 'returns empty string when file starts without any indentation',


### PR DESCRIPTION
In case project's package.json uses tabs or multiple spaces for indentation, the postinstall script of nativescript-dev-webpack overwrites it with two spaces whenever it is executed.
The problem is that the plugin tries to modify the package.json and persists it on every operation.
Fix the behavior by checking the indentation character and use it when stringifying the content.
Also compare the current content of the file with the one we will write and skip the write operation in case they match.
Add unit tests for the new methods.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [x] Tests for the changes are included.

## What is the current behavior?
When the project's package.json is indented with tabs or more than two spaces, running the postinstall script of the plugin overwrites the content with indentation with two spaces.

## What is the new behavior?
Indentation is persisted. Also package.json will not be overwritten in case there's no need.

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/4190

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla