### PR TITLE
refactor: remove unused `extract-text-webpack-plugin`

### DIFF
--- a/dependencyManager.js
+++ b/dependencyManager.js
@@ -54,7 +54,6 @@ function removeObsoleteDeps(packageJson) {
         "raw-loader",
         "css-loader",
         "nativescript-worker-loader",
-        "extract-text-webpack-plugin",
         "uglifyjs-webpack-plugin",
         "@angular-devkit/core",
         "resolve-url-loader",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "clean-webpack-plugin": "~1.0.0",
     "copy-webpack-plugin": "~4.6.0",
     "css-loader": "~1.0.0",
-    "extract-text-webpack-plugin": "~3.0.2",
     "global-modules-path": "2.0.0",
     "minimatch": "3.0.4",
     "nativescript-hook": "0.2.4",


### PR DESCRIPTION
The plugin is not used in the webpack configurations anymore and can be removed.