### PR TITLE
feat(TypeScript): use `ts-loader` instead of `awesome-typescript-loader`

### DIFF
--- a/demo/TypeScriptApp/webpack.config.js
+++ b/demo/TypeScriptApp/webpack.config.js
@@ -88,8 +88,8 @@ module.exports = env => {
             alias: {
                 '~': appFullPath
             },
-            // don't resolve symlinks to symlinked modules
-            symlinks: false
+            // resolve symlinks to symlinked modules
+            symlinks: true
         },
         resolveLoader: {
             // don't resolve symlinks to symlinked loaders
@@ -192,10 +192,14 @@ module.exports = env => {
                 {
                     test: /\.ts$/,
                     use: {
-                        loader: "awesome-typescript-loader",
-                        options: { configFileName: "tsconfig.tns.json" },
+                        loader: "ts-loader",
+                        options: {
+                            configFile: "tsconfig.tns.json",
+                            allowTsInNodeModules: true,
+                        },
                     }
                 },
+
             ]
         },
         plugins: [

--- a/dependencyManager.js
+++ b/dependencyManager.js
@@ -58,7 +58,6 @@ function removeObsoleteDeps(packageJson) {
         "uglifyjs-webpack-plugin",
         "@angular-devkit/core",
         "resolve-url-loader",
-        "awesome-typescript-loader",
         "sass-loader",
     ];
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
   },
   "dependencies": {
     "@angular-devkit/core": "~7.1.0",
-    "awesome-typescript-loader": "~5.2.1",
     "clean-webpack-plugin": "~1.0.0",
     "copy-webpack-plugin": "~4.6.0",
     "css-loader": "~1.0.0",

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -86,8 +86,8 @@ module.exports = env => {
             alias: {
                 '~': appFullPath
             },
-            // don't resolve symlinks to symlinked modules
-            symlinks: false
+            // resolve symlinks to symlinked modules
+            symlinks: true
         },
         resolveLoader: {
             // don't resolve symlinks to symlinked loaders
@@ -190,8 +190,11 @@ module.exports = env => {
                 {
                     test: /\.ts$/,
                     use: {
-                        loader: "awesome-typescript-loader",
-                        options: { configFileName: "tsconfig.tns.json" },
+                        loader: "ts-loader",
+                        options: {
+                            configFile: "tsconfig.tns.json",
+                            allowTsInNodeModules: true,
+                        },
                     }
                 },
             ]


### PR DESCRIPTION
We executed some performance tests to compare `ts-loader` and `awesome-typescript-loader`. The difference in the build time between the two is insignificant. On the other hand, the `ts-loader` is 50% smaller than `awesome-typescript-loader` and is a dependency of the `nativescript-dev-webpack` package because it is needed in the {N}-Vue projects anyway.