### PR TITLE
fix(Vue): disable mangling of function names when building in production mode

### DIFF
--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -143,6 +143,7 @@ module.exports = env => {
                             'collapse_vars': platform !== "android",
                             sequences: platform !== "android",
                         },
+                        keep_fnames: true,
                     },
                 }),
             ],


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests

## What is the current behavior?
When building {N} Vue apps in production mode the function names are renamed by UglifyJS to make the bundle smaller.
This causes problems when some `tns-core-modules` components are renamed (`SegmentedBar`, `FormattedString`).

```
tns run ios --bundle --env.production
```

## What is the new behavior?
The function names are not renamed anymore.

fixes https://github.com/nativescript-vue/vue-cli-template/issues/105 for the {N} CLI Vue template.