### PR TITLE
fix(Angular): add hot loader for lazy loaded NgModules

### DIFF
--- a/lazy-ngmodule-hot-loader.js
+++ b/lazy-ngmodule-hot-loader.js
@@ -1,0 +1,17 @@
+const { safeGet } = require("./projectHelpers");
+
+const LAZY_RESOURCE_CONTEXT = "$$_lazy_route_resource";
+const HOT_SELF_ACCEPT = "module.hot && module.hot.accept()";
+
+const isLazyLoadedNgModule = resource => {
+    const issuer = safeGet(resource, "issuer");
+    const issuerContext = safeGet(issuer, "context");
+
+    return issuerContext && issuerContext.endsWith(LAZY_RESOURCE_CONTEXT);
+};
+
+module.exports = function (source) {
+    return isLazyLoadedNgModule(this._module) ?
+        `${source};${HOT_SELF_ACCEPT}`:
+        source;
+};

--- a/projectHelpers.js
+++ b/projectHelpers.js
@@ -110,5 +110,6 @@ module.exports = {
     isTypeScript,
     writePackageJson,
     convertSlashesInPath,
-    getIndentationCharacter
+    getIndentationCharacter,
+    safeGet,
 };

--- a/projectHelpers.spec.js
+++ b/projectHelpers.spec.js
@@ -1,4 +1,4 @@
-const { getIndentationCharacter, writePackageJson } = require("./projectHelpers");
+const { getIndentationCharacter, writePackageJson, safeGet } = require("./projectHelpers");
 const fs = require("fs");
 
 describe('projectHelpers', () => {
@@ -54,6 +54,28 @@ describe('projectHelpers', () => {
             it(testName, () => {
                 expect(getIndentationCharacter(input)).toEqual(expectedResult);
             });
+        });
+    });
+
+    describe('safeGet', () => {
+        it('should return the correct value of existing properties', () => {
+            const obj = { a: 15 };
+            expect(safeGet(obj, 'a')).toBe(15);
+        });
+
+        it('should return undefined for unexisting properties', () => {
+            const obj = { a: 15 };
+            expect(safeGet(obj, 'random')).toBeUndefined();
+        });
+
+        it('should return undefined when the first argument is undefined', () => {
+            let obj;
+            expect(safeGet(obj, 'random')).toBeUndefined();
+        });
+
+        it('should return undefined when the first argument is not an object and does not have inherited property with the queried name', () => {
+            const num = 15;
+            expect(safeGet(num, 'random')).toBeUndefined();
         });
     });
 

--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -192,6 +192,7 @@ module.exports = env => {
                     test: /(?:\.ngfactory\.js|\.ngstyle\.js|\.ts)$/,
                     use: [
                         "nativescript-dev-webpack/moduleid-compat-loader",
+                        "nativescript-dev-webpack/lazy-ngmodule-hot-loader",
                         "@ngtools/webpack",
                     ]
                 },


### PR DESCRIPTION
## What is the current behavior?
In NativeScript Angular the hot updates are only accepted in the entry file (`main.ts`). The lazy loaded NgModules are not directly imported anywhere in the dependency graph with root `main.ts`. That's why the hot updates in lazy modules don't bubble up to the accept in `main.ts` and HMR doesn't work in lazy modules.

## What is the new behavior?
Every lazy loaded NgModule is augmented with HMR self-accept during build by the `lazy-ngmodule-hot-loader`.

fixes https://github.com/NativeScript/nativescript-angular/issues/1564


BREAKING CHANGES:


The `lazy-ngmodule-hot-loader` should be added to the webpack configuration.

**BEFORE**
``` js
// webpack.config.js
                {
                    test: /(?:\.ngfactory\.js|\.ngstyle\.js|\.ts)$/,
                    use: [
                        "nativescript-dev-webpack/moduleid-compat-loader",
                        "@ngtools/webpack",
                    ]
                },
// ...
```

**AFTER**
``` js
// webpack.config.js
                {
                    test: /(?:\.ngfactory\.js|\.ngstyle\.js|\.ts)$/,
                    use: [
                        "nativescript-dev-webpack/moduleid-compat-loader",
                        "nativescript-dev-webpack/lazy-ngmodule-hot-loader",
                        "@ngtools/webpack",
                    ]
                },
// ...
```
