### PR TITLE
fix-next(Angular): HMR for lazy loaded NgModules

### DIFF
--- a/lazy-ngmodule-hot-loader.js
+++ b/lazy-ngmodule-hot-loader.js
@@ -1,7 +1,12 @@
 const { safeGet } = require("./projectHelpers");
 
 const LAZY_RESOURCE_CONTEXT = "$$_lazy_route_resource";
-const HOT_SELF_ACCEPT = "module.hot && module.hot.accept()";
+const HOT_SELF_ACCEPT = `
+    if (module.hot) {
+        module.hot.accept();
+        module.hot.dispose(() => global.__hmrRefresh({}));
+    }
+    `;
 
 const isLazyLoadedNgModule = resource => {
     const issuer = safeGet(resource, "issuer");
@@ -12,6 +17,6 @@ const isLazyLoadedNgModule = resource => {
 
 module.exports = function (source) {
     return isLazyLoadedNgModule(this._module) ?
-        `${source};${HOT_SELF_ACCEPT}`:
+        `${source};${HOT_SELF_ACCEPT}` :
         source;
 };

--- a/lazy-ngmodule-hot-loader.js
+++ b/lazy-ngmodule-hot-loader.js
@@ -1,12 +1,20 @@
 const { safeGet } = require("./projectHelpers");
 
 const LAZY_RESOURCE_CONTEXT = "$$_lazy_route_resource";
-const HOT_SELF_ACCEPT = `
+const HOT_SELF_ACCEPT = "module.hot.accept();";
+const HOT_DISPOSE = `
+module.hot.dispose(() => {
+    // Currently the context is needed only for application style modules.
+    const MODULE_CONTEXT = "{}";
+    global.__hmrRefresh(MODULE_CONTEXT);
+});
+`;
+const HMR_HANDLER = `
     if (module.hot) {
-        module.hot.accept();
-        module.hot.dispose(() => global.__hmrRefresh({}));
+        ${HOT_SELF_ACCEPT}
+        ${HOT_DISPOSE}
     }
-    `;
+`;
 
 const isLazyLoadedNgModule = resource => {
     const issuer = safeGet(resource, "issuer");
@@ -17,6 +25,6 @@ const isLazyLoadedNgModule = resource => {
 
 module.exports = function (source) {
     return isLazyLoadedNgModule(this._module) ?
-        `${source};${HOT_SELF_ACCEPT}` :
+        `${source};${HMR_HANDLER}` :
         source;
 };

--- a/lazy-ngmodule-hot-loader.js
+++ b/lazy-ngmodule-hot-loader.js
@@ -5,8 +5,8 @@ const HOT_SELF_ACCEPT = "module.hot.accept();";
 const HOT_DISPOSE = `
 module.hot.dispose(() => {
     // Currently the context is needed only for application style modules.
-    const MODULE_CONTEXT = "{}";
-    global.__hmrRefresh(MODULE_CONTEXT);
+    const moduleContext = "{}";
+    global.__hmrRefresh(moduleContext);
 });
 `;
 const HMR_HANDLER = `


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->
Currently, the `lazy-ngmodule-hot-loader` [adds](https://github.com/NativeScript/nativescript-dev-webpack/commit/6a9db32b9ef0205194d017f1803d2a5c6d21b4b8) a HMR self-accept to every lazy loaded NgModule during a build.

## What is the new behavior?
<!-- Describe the changes. -->
After [alignment](https://github.com/NativeScript/nativescript-dev-webpack/commit/fe4abfb548b91b12387c62ee6c168b1bd911214f) of the HMR lifecycle of NativeScript Angular with non-Angular applications, it requires a handler to update the app after module replacement.

<!-- Fixes/Implements/Closes #[Issue Number]. -->

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla