### PR TITLE
fix: lazy-ngmodule-hot-loader breaks the sourceMaps

### DIFF
--- a/lazy-ngmodule-hot-loader.js
+++ b/lazy-ngmodule-hot-loader.js
@@ -21,8 +21,10 @@ const isLazyLoadedNgModule = resource => {
     return issuerContext && issuerContext.endsWith(LAZY_RESOURCE_CONTEXT);
 };
 
-module.exports = function (source) {
-    return isLazyLoadedNgModule(this._module) ?
-        `${source};${HMR_HANDLER}` :
+module.exports = function (source, map) {
+    const modifiedSource = isLazyLoadedNgModule(this._module) ?
+        `${source};${HMR_HANDLER}`:
         source;
+
+    this.callback(null, modifiedSource, map);
 };


### PR DESCRIPTION
The `lazy-ngmodule-hot-loader` breaks sourceMaps as it does not pass them to the next loaders. This breaks debugging with `--bundle` in VSCode extension as the files included in the `sourcesContent` cannot be mapped correctly to local files.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [x] Tests for the changes are included.

## What is the current behavior?
* Unable to debug Angular projects in VSCode.
* When debugging Angular projects in Chrome DevTools, the content of the files under `webpack` is not the same as your actual content - it's not TypeScript anymore:


## What is the new behavior?
* You can debug Angular projects in VSCode
* Sources under webpack in Chrome DevTools are correct

Fixes https://github.com/NativeScript/nativescript-vscode-extension/issues/232

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla