### PR TITLE
feat(Vue): option to enable sourcemaps

### DIFF
--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -44,6 +44,7 @@ module.exports = env => {
         production, // --env.production
         report, // --env.report
         hmr, // --env.hmr
+        sourceMap, // --env.sourceMap
     } = env;
 
     const externals = (env.externals || []).map((e) => { // --env.externals
@@ -111,7 +112,7 @@ module.exports = env => {
             "fs": "empty",
             "__dirname": false,
         },
-        devtool: "none",
+        devtool: sourceMap ? "inline-source-map" : "none",
         optimization: {
             splitChunks: {
                 cacheGroups: {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it. _**No relevant issue that I could find**_
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included. _**Changed code is not tested that I can see**_

## What is the current behavior?
The JS and Angular templates include an option to enable sourcemaps, the Vue one doesn't. This means the VS Code integration (or any debugger) cannot breakpoint and debug as sourcemaps are not present.

## What is the new behavior?
The Vue template has an option for enabling sourcemaps, using `--env.sourceMap`

I've tested this by debugging with breakpoints VS Code, which is fixed by this change.


[CLA]: http://www.nativescript.org/cla ✅ 