### PR TITLE
fix: optimize platform specific files resolver

### DIFF
--- a/host/resolver.ts
+++ b/host/resolver.ts
@@ -1,7 +1,7 @@
 import { parse, join } from "path";
 import { statSync } from "fs";
 
-export function getResolver(platforms: string[]) {
+export function getResolver(platforms: string[], explicitResolve: string[] = []) {
     const platformSpecificExt = [".ts", ".js", ".scss", ".less", ".css", ".html", ".xml", ".vue", ".json"];
     const nsPackageFilters = [
         'nativescript',
@@ -13,9 +13,11 @@ export function getResolver(platforms: string[]) {
         const nmIndex = path.lastIndexOf('node_modules');
 
         if (nmIndex !== -1) {
-            const pathParts = path.substr(nmIndex + 'node_modules'.length).split(/[/\\\-_]/);
-
-            if (pathParts.every(p => nsPackageFilters.every(f => f !== p))) {
+            const subPath = path.substr(nmIndex + 'node_modules'.length).replace(/\\/g, '/');
+            const shouldResolve = explicitResolve.length && explicitResolve.some(packageName => subPath.indexOf(packageName) !== -1);
+            const pathParts = subPath.split(/[/\-_]/);
+    
+            if (!shouldResolve && pathParts.every(p => nsPackageFilters.every(f => f !== p))) {
                 return path;
             }
         }

--- a/host/resolver.ts
+++ b/host/resolver.ts
@@ -1,19 +1,23 @@
-import {
-    parse,
-    join,
-} from "path";
+import { parse, join } from "path";
 import { statSync } from "fs";
 
 export function getResolver(platforms: string[]) {
     const platformSpecificExt = [".ts", ".js", ".scss", ".less", ".css", ".html", ".xml", ".vue", ".json"];
     const nsPackageFilters = [
-        'nativescript-',
-        'tns-'
+        'nativescript',
+        'tns',
+        'ns'
     ];
 
     return function (path: string) {
-        if (path.indexOf('node_modules') !== -1 && nsPackageFilters.every(f => path.indexOf(f) === -1)) {
-            return path;
+        const nmIndex = path.lastIndexOf('node_modules');
+
+        if (nmIndex !== -1) {
+            const pathParts = path.substr(nmIndex + 'node_modules'.length).split(/[/\\\-_]/);
+
+            if (pathParts.every(p => nsPackageFilters.every(f => f !== p))) {
+                return path;
+            }
         }
 
         const { dir, name, ext } = parse(path);

--- a/host/resolver.ts
+++ b/host/resolver.ts
@@ -5,19 +5,32 @@ import {
 import { statSync } from "fs";
 
 export function getResolver(platforms: string[]) {
-    return function(path: string) {
+    const platformSpecificExt = [".ts", ".js", ".scss", ".less", ".css", ".html", ".xml"];
+    const nsPackageFilters = [
+        'nativescript-',
+        'tns-'
+    ];
+
+    return function (path: string) {
+        if (path.indexOf('node_modules') !== -1 && nsPackageFilters.every(f => path.indexOf(f) === -1)) {
+            return path;
+        }
+
         const { dir, name, ext } = parse(path);
+
+        if (platformSpecificExt.indexOf(ext) === -1) {
+            return path;
+        }
 
         for (const platform of platforms) {
             const platformFileName = `${name}.${platform}${ext}`;
             const platformPath = toSystemPath(join(dir, platformFileName));
 
             try {
-                const stat = statSync(platformPath);
-                if (stat && stat.isFile()) {
+                if (statSync(platformPath)) {
                     return platformPath;
                 }
-            } catch(_e) {
+            } catch (_e) {
                 // continue checking the other platforms
             }
         }
@@ -34,6 +47,6 @@ function toSystemPath(path: string) {
 
     const drive = path.match(/^\\(\w)\\(.*)$/);
     return drive ?
-        `${drive[1]}:\\${drive[2]}`:
+        `${drive[1]}:\\${drive[2]}` :
         path;
 }

--- a/host/resolver.ts
+++ b/host/resolver.ts
@@ -5,7 +5,7 @@ import {
 import { statSync } from "fs";
 
 export function getResolver(platforms: string[]) {
-    const platformSpecificExt = [".ts", ".js", ".scss", ".less", ".css", ".html", ".xml"];
+    const platformSpecificExt = [".ts", ".js", ".scss", ".less", ".css", ".html", ".xml", ".vue", ".json"];
     const nsPackageFilters = [
         'nativescript-',
         'tns-'


### PR DESCRIPTION
## What is the current behavior?
The platform specific files resolver for `.tns`, `.ios`, `.android` files is having performance issues on webpack and seems to break (make it run very slow like its for the first time) the incremental compilation. This is happening in big projects with many files in the `node_modules` directory, as the current implementation makes a file system call for each file.

## What is the new behavior?
The resolver now handles only the files that are considered to support platform specific names e.g:
* packages in `node_modules` with `nativescript`, `tns` or `ns` anywhere in the name
* only files with following extensions: `[".ts", ".js", ".scss", ".less", ".css", ".html", ".xml", ".vue", ".json"]`