### PR TITLE
refactor: skip copying of the native app resources on `tns preview`

### DIFF
--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -237,14 +237,6 @@ module.exports = env => {
             }),
             // Remove all files from the out dir.
             new CleanWebpackPlugin([`${dist}/**/*`]),
-            // Copy native app resources to out dir.
-            new CopyWebpackPlugin([
-                {
-                    from: `${appResourcesFullPath}/${appResourcesPlatformDir}`,
-                    to: `${dist}/App_Resources/${appResourcesPlatformDir}`,
-                    context: projectRoot
-                },
-            ]),
             // Copy assets to out dir. Add your own globs as needed.
             new CopyWebpackPlugin([
                 { from: { glob: "fonts/**" } },
@@ -264,6 +256,18 @@ module.exports = env => {
             new nsWebpack.WatchStateLoggerPlugin(),
         ],
     };
+
+    // Copy the native app resources to the out dir
+    // only if doing a full build (tns run/build) and not previewing (tns preview)
+    if (env.externals.length === 0) {
+        config.plugins.push(new CopyWebpackPlugin([
+            {
+                from: `${appResourcesFullPath}/${appResourcesPlatformDir}`,
+                to: `${dist}/App_Resources/${appResourcesPlatformDir}`,
+                context: projectRoot
+            },
+        ]));
+    }
 
 
     if (report) {

--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -271,7 +271,7 @@ module.exports = env => {
 
     // Copy the native app resources to the out dir
     // only if doing a full build (tns run/build) and not previewing (tns preview)
-    if (env.externals.length === 0) {
+    if (!externals || externals.length === 0) {
         config.plugins.push(new CopyWebpackPlugin([
             {
                 from: `${appResourcesFullPath}/${appResourcesPlatformDir}`,

--- a/templates/webpack.config.spec.ts
+++ b/templates/webpack.config.spec.ts
@@ -83,7 +83,8 @@ describe('webpack.config.js', () => {
                     });
 
                     it('returns empty array when externals are not passed', () => {
-                        const config = webpackConfig(getInput({ platform }));
+                        const input = getInput({ platform });
+                        const config = webpackConfig(input);
                         expect(config.externals).toEqual([]);
                     });
 

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -194,14 +194,6 @@ module.exports = env => {
             }),
             // Remove all files from the out dir.
             new CleanWebpackPlugin([ `${dist}/**/*` ]),
-           // Copy native app resources to out dir.
-            new CopyWebpackPlugin([
-              {
-                from: `${appResourcesFullPath}/${appResourcesPlatformDir}`,
-                to: `${dist}/App_Resources/${appResourcesPlatformDir}`,
-                context: projectRoot
-              },
-            ]),
             // Copy assets to out dir. Add your own globs as needed.
             new CopyWebpackPlugin([
                 { from: { glob: "fonts/**" } },
@@ -224,6 +216,18 @@ module.exports = env => {
             new nsWebpack.WatchStateLoggerPlugin(),
         ],
     };
+
+    // Copy the native app resources to the out dir
+    // only if doing a full build (tns run/build) and not previewing (tns preview)
+    if (env.externals.length === 0) {
+        config.plugins.push(new CopyWebpackPlugin([
+            {
+                from: `${appResourcesFullPath}/${appResourcesPlatformDir}`,
+                to: `${dist}/App_Resources/${appResourcesPlatformDir}`,
+                context: projectRoot
+            },
+        ]));
+    }
 
     if (report) {
         // Generate report files for bundles content

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -226,7 +226,7 @@ module.exports = env => {
 
     // Copy the native app resources to the out dir
     // only if doing a full build (tns run/build) and not previewing (tns preview)
-    if (env.externals.length === 0) {
+    if (!externals || externals.length === 0) {
         config.plugins.push(new CopyWebpackPlugin([
             {
                 from: `${appResourcesFullPath}/${appResourcesPlatformDir}`,

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -207,14 +207,6 @@ module.exports = env => {
             }),
             // Remove all files from the out dir.
             new CleanWebpackPlugin([ `${dist}/**/*` ]),
-            // Copy native app resources to out dir.
-            new CopyWebpackPlugin([
-              {
-                from: `${appResourcesFullPath}/${appResourcesPlatformDir}`,
-                to: `${dist}/App_Resources/${appResourcesPlatformDir}`,
-                context: projectRoot
-              },
-            ]),
             // Copy assets to out dir. Add your own globs as needed.
             new CopyWebpackPlugin([
                 { from: { glob: "fonts/**" } },
@@ -237,6 +229,18 @@ module.exports = env => {
             new nsWebpack.WatchStateLoggerPlugin(),
         ],
     };
+
+    // Copy the native app resources to the out dir
+    // only if doing a full build (tns run/build) and not previewing (tns preview)
+    if (env.externals.length === 0) {
+        config.plugins.push(new CopyWebpackPlugin([
+            {
+                from: `${appResourcesFullPath}/${appResourcesPlatformDir}`,
+                to: `${dist}/App_Resources/${appResourcesPlatformDir}`,
+                context: projectRoot
+            },
+        ]));
+    }
 
     if (report) {
         // Generate report files for bundles content

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -239,7 +239,7 @@ module.exports = env => {
 
     // Copy the native app resources to the out dir
     // only if doing a full build (tns run/build) and not previewing (tns preview)
-    if (env.externals.length === 0) {
+    if (!externals || externals.length === 0) {
         config.plugins.push(new CopyWebpackPlugin([
             {
                 from: `${appResourcesFullPath}/${appResourcesPlatformDir}`,

--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -216,12 +216,6 @@ module.exports = env => {
             }),
             // Remove all files from the out dir.
             new CleanWebpackPlugin([`${dist}/**/*`]),
-            // Copy native app resources to out dir.
-            new CopyWebpackPlugin([{
-                from: `${appResourcesFullPath}/${appResourcesPlatformDir}`,
-                to: `${dist}/App_Resources/${appResourcesPlatformDir}`,
-                context: projectRoot,
-            }]),
             // Copy assets to out dir. Add your own globs as needed.
             new CopyWebpackPlugin([
                 { from: { glob: "fonts/**" } },
@@ -244,6 +238,18 @@ module.exports = env => {
             new nsWebpack.WatchStateLoggerPlugin(),
         ],
     };
+
+    // Copy the native app resources to the out dir
+    // only if doing a full build (tns run/build) and not previewing (tns preview)
+    if (env.externals.length === 0) {
+        config.plugins.push(new CopyWebpackPlugin([
+            {
+                from: `${appResourcesFullPath}/${appResourcesPlatformDir}`,
+                to: `${dist}/App_Resources/${appResourcesPlatformDir}`,
+                context: projectRoot
+            },
+        ]));
+    }
 
     if (report) {
         // Generate report files for bundles content

--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -248,7 +248,7 @@ module.exports = env => {
 
     // Copy the native app resources to the out dir
     // only if doing a full build (tns run/build) and not previewing (tns preview)
-    if (env.externals.length === 0) {
+    if (!externals || externals.length === 0) {
         config.plugins.push(new CopyWebpackPlugin([
             {
                 from: `${appResourcesFullPath}/${appResourcesPlatformDir}`,


### PR DESCRIPTION
The assets from the `App_Resources/${platform}` folder are copied to the out directory (`platforms/.../app`) by the `CopyWebpackPlugin`. This step is not required when running `tns preview`, because no native build is performed and the native resources are not needed.