### PR TITLE
refactor: rename module to path in context object

### DIFF
--- a/bundle-config-loader.js
+++ b/bundle-config-loader.js
@@ -12,13 +12,13 @@ module.exports = function (source) {
                 hmrUpdate();
             };
 
-            global.hmrRefresh = function({ type, module } = {}) {
+            global.hmrRefresh = function({ type, path} = {}) {
                 if (global.__initialHmrUpdate) {
                     return;
                 }
 
                 setTimeout(() => {
-                    global.__hmrSyncBackup({ type, module });
+                    global.__hmrSyncBackup({ type, path });
                 });
             };
 

--- a/hot-loader-helper.js
+++ b/hot-loader-helper.js
@@ -1,9 +1,9 @@
-module.exports.reload = function ({ type, module }) {
+module.exports.reload = function ({ type, path }) {
     return `
     if (module.hot) {
         module.hot.accept();
         module.hot.dispose(() => {
-            global.hmrRefresh({ type: '${type}', module: '${module}' });
+            global.hmrRefresh({ type: '${type}', path: '${path}' });
         })
     }
 `};

--- a/markup-hot-loader.js
+++ b/markup-hot-loader.js
@@ -3,5 +3,5 @@ const { reload } = require("./hot-loader-helper");
 module.exports = function (source) {
     const typeMarkup = "markup";
     const modulePath = this.resourcePath.replace(this.rootContext, ".");
-    return `${source};${reload({ type: typeMarkup, module: modulePath })}`;
+    return `${source};${reload({ type: typeMarkup, path: modulePath })}`;
 };

--- a/script-hot-loader.js
+++ b/script-hot-loader.js
@@ -3,5 +3,5 @@ const { reload } = require("./hot-loader-helper");
 module.exports = function (source) {
     const typeScript = "script";
     const modulePath = this.resourcePath.replace(this.rootContext, ".");
-    return `${source};${reload({ type: typeScript, module: modulePath })}`;
+    return `${source};${reload({ type: typeScript, path: modulePath })}`;
 };

--- a/style-hot-loader.js
+++ b/style-hot-loader.js
@@ -3,5 +3,5 @@ const { reload } = require("./hot-loader-helper");
 module.exports = function (source) {
     const typeStyle = "style";
     const modulePath = this.resourcePath.replace(this.rootContext, ".");
-    return `${source};${reload({ type: typeStyle, module: modulePath })}`;
+    return `${source};${reload({ type: typeStyle, path: modulePath })}`;
 };


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

The `global.__hmrRefresh()` function accepts a context object which consists of two properties:
- a `type` of the module
- a relative `path` of the module from the application root

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->
The context object consist of `type` and `module` properties.

## What is the new behavior?
<!-- Describe the changes. -->
The context object consist of `type` and `path` properties.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla