### PR TITLE
feat(snapshot): The parameters passed to mksnapshot are now retrieved…

### DIFF
--- a/androidProjectHelpers.js
+++ b/androidProjectHelpers.js
@@ -34,6 +34,19 @@ const getAndroidV8Version = (projectDir) => {
     }
 }
 
+const getMksnapshotParams = (projectDir) => {
+    try {
+        const androidSettingsJSON = getAndroidSettingsJson(projectDir);
+        if (androidSettingsJSON !== null) {
+            return androidSettingsJSON.mksnapshotParams;
+        } else {
+            return null;
+        }
+    } catch (e) {
+        return null;
+    }
+};
+
 const getAndroidSettingsJson = projectDir => {
     const androidSettingsJsonPath = resolve(projectDir, PLATFORMS_ANDROID, "settings.json");
     if (existsSync(androidSettingsJsonPath)) {
@@ -49,4 +62,5 @@ module.exports = {
     ANDROID_CONFIGURATIONS_PATH,
     getAndroidRuntimeVersion,
     getAndroidV8Version,
+    getMksnapshotParams
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-dev-webpack",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "main": "index",
   "description": "",
   "homepage": "http://www.telerik.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-dev-webpack",
-  "version": "0.19.3",
+  "version": "0.19.2",
   "main": "index",
   "description": "",
   "homepage": "http://www.telerik.com",

--- a/snapshot/android/project-snapshot-generator.js
+++ b/snapshot/android/project-snapshot-generator.js
@@ -17,6 +17,7 @@ const {
     ANDROID_CONFIGURATIONS_PATH,
     getAndroidRuntimeVersion,
     getAndroidV8Version,
+    getMksnapshotParams
 } = require("../../androidProjectHelpers");
 
 const MIN_ANDROID_RUNTIME_VERSION = "3.0.0";
@@ -227,6 +228,9 @@ ProjectSnapshotGenerator.prototype.generate = function (generationOptions) {
 
     const noV8VersionFoundMessage = `Cannot find suitable v8 version!`;
     let shouldRethrow = false;
+
+    const mksnapshotParams = getMksnapshotParams(this.options.projectRoot);
+
     return this.getV8Version(generationOptions).then(v8Version => {
         shouldRethrow = true;
         if (!v8Version) {
@@ -241,6 +245,7 @@ ProjectSnapshotGenerator.prototype.generate = function (generationOptions) {
             useLibs: generationOptions.useLibs || false,
             inputFiles: generationOptions.inputFiles || [join(this.options.projectRoot, "__snapshot.js")],
             androidNdkPath,
+            mksnapshotParams: mksnapshotParams
         };
 
         return generator.generate(options).then(() => {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

Related to https://github.com/NativeScript/android-runtime/issues/1263

## What is the current behavior?

The parameters passed to the **mksnapshot** tool are hardcoded in the webpack plugin (for example the `--profile_deserialization` flag).

## What is the new behavior?

The parameters passed to the **mksnapshot** tool are retrieved from the [settings.json](https://github.com/NativeScript/android-runtime/blob/darind/v8-7.2.502.24/build-artifacts/project-template-gradle/settings.json#L3) file of the installed android runtime. A fallback mechanism is provided for older android runtimes which do not have those parameters.

## Why is this change required?

Recent V8 versions (notably >= 7.0) have become very strict on the parameters passed to **mksnapshot**. They must exactly match the parameters used to create V8's internal snapshot during the compilation process. Otherwise the layout of the snapshot binary might become invalid and result into segmentation faults. Because those parameters are very strictly related to the V8 version it makes more sense to store them as part of the runtime as they might change often.

For reference, here's a related issue in which we have discussed with Google engineers, various crashes related to those parameters: https://bugs.chromium.org/p/v8/issues/detail?id=8576. For example the `--turbo_instruction_scheduling` flag must now be specified.