### PR TITLE
chore(ns-support-hmr-ng transformer): support app options variable

### DIFF
--- a/transformers/ns-support-hmr-ng.spec.ts
+++ b/transformers/ns-support-hmr-ng.spec.ts
@@ -1,7 +1,7 @@
 import { tags } from "@angular-devkit/core";
 import { createTypescriptContext, transformTypescript } from "@ngtools/webpack/src/transformers";
 import { nsReplaceBootstrap } from './ns-replace-bootstrap';
-import { nsSupportHmrNg, getHandleHmrOptionsCode, getAcceptMainModuleCode, GeneratedDynamicAppOptions } from "./ns-support-hmr-ng";
+import { nsSupportHmrNg, getHmrOptionsCode, getAcceptMainModuleCode, GeneratedDynamicAppOptions } from "./ns-support-hmr-ng";
 import { AngularCompilerPlugin } from "@ngtools/webpack";
 
 describe("@ngtools/webpack transformers", () => {
@@ -14,282 +14,321 @@ describe("@ngtools/webpack transformers", () => {
         const handleHmrOptionsDeclaration = `var ${GeneratedDynamicAppOptions} = {};`;
         const nsStaticPlatformCall = `nativescript_angular_platform_Generated.platformNativeScript`;
         const nsDynamicPlatformCall = `nativescript_angular_platform_Generated.platformNativeScriptDynamic`;
-        const handleHmrOptionsCode = getHandleHmrOptionsCode("AppModule", "./app/app.module");
+        const handleHmrOptionsCode = getHmrOptionsCode("AppModule", "./app/app.module");
         const acceptMainModuleCode = getAcceptMainModuleCode("./app/app.module");
-        const handleHmrOptionsAotCode = getHandleHmrOptionsCode("AppModuleNgFactory", "./test-file.ts.ngfactory");
+        const handleHmrOptionsAotCode = getHmrOptionsCode("AppModuleNgFactory", "./test-file.ts.ngfactory");
         const acceptMainModuleAotCode = getAcceptMainModuleCode("./test-file.ts.ngfactory");
+        const getAppOptions = (currentAppOptionsString?: string) => {
+            return `Object.assign(${currentAppOptionsString || "{}"}, ${GeneratedDynamicAppOptions})`
+        };
+        const defaultAppOptions = getAppOptions();
         const testCases = [{
             name: "should handle HMR when platformNativeScriptDynamic is called without arguments",
             rawFile: `
-                    import { platformNativeScriptDynamic } from "nativescript-angular/platform";
-                    import { AppModule } from "./app/app.module";
-                    platformNativeScriptDynamic().bootstrapModule(AppModule);
-                `,
+                import { platformNativeScriptDynamic } from "nativescript-angular/platform";
+                import { AppModule } from "./app/app.module";
+                platformNativeScriptDynamic().bootstrapModule(AppModule);
+            `,
             transformedFile: `
-                    ${handleHmrPlatformDynamicImport}
-                    import { AppModule } from "./app/app.module";
+                ${handleHmrPlatformDynamicImport}
+                import { AppModule } from "./app/app.module";
 
-                    ${handleHmrOptionsDeclaration}
-                    ${handleHmrOptionsCode}
-                    ${acceptMainModuleCode}
+                ${handleHmrOptionsDeclaration}
+                ${handleHmrOptionsCode}
+                ${acceptMainModuleCode}
 
-                    ${nsDynamicPlatformCall}(${GeneratedDynamicAppOptions}).bootstrapModule(AppModule);
-                `,
+                ${nsDynamicPlatformCall}(${defaultAppOptions}).bootstrapModule(AppModule);
+            `,
             transformedFileWithAot: `
-                    ${handleHmrPlatformStaticImport}
-                    ${handleAotPlatformStaticImport}
-                    ${handleAotNgFactoryImport}
+                ${handleHmrPlatformStaticImport}
+                ${handleAotPlatformStaticImport}
+                ${handleAotNgFactoryImport}
 
-                    ${handleHmrOptionsDeclaration}
-                    ${handleHmrOptionsAotCode}
-                    ${acceptMainModuleAotCode}
+                ${handleHmrOptionsDeclaration}
+                ${handleHmrOptionsAotCode}
+                ${acceptMainModuleAotCode}
 
-                    ${nsStaticPlatformCall}(${GeneratedDynamicAppOptions}).bootstrapModuleFactory(${nsFactoryImportName}.AppModuleNgFactory);
-                `
+                ${nsStaticPlatformCall}(${defaultAppOptions}).bootstrapModuleFactory(${nsFactoryImportName}.AppModuleNgFactory);
+            `
         },
         {
             name: "should not handle HMR when the AppModule import cannot be found",
             rawFile: `
-                    import { platformNativeScriptDynamic } from "nativescript-angular/platform";
-                    platformNativeScriptDynamic().bootstrapModule(SyntaxErrorModule);
-                `,
+                import { platformNativeScriptDynamic } from "nativescript-angular/platform";
+                platformNativeScriptDynamic().bootstrapModule(SyntaxErrorModule);
+            `,
             transformedFile: `
-                    import { platformNativeScriptDynamic } from "nativescript-angular/platform";
-                    platformNativeScriptDynamic().bootstrapModule(SyntaxErrorModule);
-                `,
+                import { platformNativeScriptDynamic } from "nativescript-angular/platform";
+                platformNativeScriptDynamic().bootstrapModule(SyntaxErrorModule);
+            `,
             transformedFileWithAot: `
-                    import { platformNativeScriptDynamic } from "nativescript-angular/platform";
-                    platformNativeScriptDynamic().bootstrapModule(SyntaxErrorModule);
-                `
+                import { platformNativeScriptDynamic } from "nativescript-angular/platform";
+                platformNativeScriptDynamic().bootstrapModule(SyntaxErrorModule);
+            `
         },
         {
             name: "(known limitation) should not handle HMR when the platformNativeScriptDynamic method is renamed",
             rawFile: `
-                    import { platformNativeScriptDynamic as x } from "nativescript-angular/platform";
-                    x().bootstrapModule(SyntaxErrorModule);
-                `,
+                import { platformNativeScriptDynamic as x } from "nativescript-angular/platform";
+                x().bootstrapModule(SyntaxErrorModule);
+            `,
             transformedFile: `
-                    import { platformNativeScriptDynamic as x } from "nativescript-angular/platform";
-                    x().bootstrapModule(SyntaxErrorModule);
-                `,
+                import { platformNativeScriptDynamic as x } from "nativescript-angular/platform";
+                x().bootstrapModule(SyntaxErrorModule);
+            `,
             transformedFileWithAot: `
-                    import { platformNativeScriptDynamic as x } from "nativescript-angular/platform";
-                    x().bootstrapModule(SyntaxErrorModule);
-                `
+                import { platformNativeScriptDynamic as x } from "nativescript-angular/platform";
+                x().bootstrapModule(SyntaxErrorModule);
+            `
         },
         {
             name: "(known limitation) should not handle HMR when the bootstrapModule method is renamed",
             rawFile: `
-                    import { platformNativeScriptDynamic } from "nativescript-angular/platform";
+                import { platformNativeScriptDynamic } from "nativescript-angular/platform";
 
-                    const x = platformNativeScriptDynamic().bootstrapModule;
-                    x(SyntaxErrorModule);
-                `,
+                const x = platformNativeScriptDynamic().bootstrapModule;
+                x(SyntaxErrorModule);
+            `,
             transformedFile: `
-                    import { platformNativeScriptDynamic } from "nativescript-angular/platform";
+                import { platformNativeScriptDynamic } from "nativescript-angular/platform";
 
-                    const x = platformNativeScriptDynamic().bootstrapModule;
-                    x(SyntaxErrorModule);
-                `,
+                const x = platformNativeScriptDynamic().bootstrapModule;
+                x(SyntaxErrorModule);
+            `,
             transformedFileWithAot: `
-                    import { platformNativeScriptDynamic } from "nativescript-angular/platform";
+                import { platformNativeScriptDynamic } from "nativescript-angular/platform";
 
-                    const x = platformNativeScriptDynamic().bootstrapModule;
-                    x(SyntaxErrorModule);
-                `
+                const x = platformNativeScriptDynamic().bootstrapModule;
+                x(SyntaxErrorModule);
+            `
         },
         {
             name: "should handle HMR when AOT is manually configured",
             rawFile: `
-                    import { platformNativeScript } from "nativescript-angular/platform-static";
-                    import { AppModuleNgFactory } from "./app/app.module.ngfactory";
-                    platformNativeScript().bootstrapModuleFactory(AppModuleNgFactory);
-                `,
+                import { platformNativeScript } from "nativescript-angular/platform-static";
+                import { AppModuleNgFactory } from "./app/app.module.ngfactory";
+                platformNativeScript().bootstrapModuleFactory(AppModuleNgFactory);
+            `,
             transformedFile: `
-                    ${handleHmrPlatformStaticImport}
-                    import { AppModuleNgFactory } from "./app/app.module.ngfactory";
+                ${handleHmrPlatformStaticImport}
+                import { AppModuleNgFactory } from "./app/app.module.ngfactory";
 
-                    ${handleHmrOptionsDeclaration}
-                    ${getHandleHmrOptionsCode("AppModuleNgFactory", "./app/app.module.ngfactory")}
-                    ${getAcceptMainModuleCode("./app/app.module.ngfactory")}
+                ${handleHmrOptionsDeclaration}
+                ${getHmrOptionsCode("AppModuleNgFactory", "./app/app.module.ngfactory")}
+                ${getAcceptMainModuleCode("./app/app.module.ngfactory")}
 
-                    ${nsStaticPlatformCall}(${GeneratedDynamicAppOptions}).bootstrapModuleFactory(AppModuleNgFactory);
-                `,
+                ${nsStaticPlatformCall}(${defaultAppOptions}).bootstrapModuleFactory(AppModuleNgFactory);
+            `,
             transformedFileWithAot: `
-                    ${handleHmrPlatformStaticImport}
-                    import { AppModuleNgFactory } from "./app/app.module.ngfactory";
+                ${handleHmrPlatformStaticImport}
+                import { AppModuleNgFactory } from "./app/app.module.ngfactory";
 
-                    ${handleHmrOptionsDeclaration}
-                    ${getHandleHmrOptionsCode("AppModuleNgFactory", "./app/app.module.ngfactory")}
-                    ${getAcceptMainModuleCode("./app/app.module.ngfactory")}
+                ${handleHmrOptionsDeclaration}
+                ${getHmrOptionsCode("AppModuleNgFactory", "./app/app.module.ngfactory")}
+                ${getAcceptMainModuleCode("./app/app.module.ngfactory")}
 
-                    ${nsStaticPlatformCall}(${GeneratedDynamicAppOptions}).bootstrapModuleFactory(AppModuleNgFactory);
-                `
+                ${nsStaticPlatformCall}(${defaultAppOptions}).bootstrapModuleFactory(AppModuleNgFactory);
+            `
         },
         {
             name: "should handle HMR when platformNativeScriptDynamic is called without arguments and non default app module",
             customAppModuleName: "CustomModule",
             rawFile: `
-                    import { platformNativeScriptDynamic } from "nativescript-angular/platform";
-                    import { CustomModule } from "./custom/custom.module";
-                    platformNativeScriptDynamic().bootstrapModule(CustomModule);
-                `,
+                import { platformNativeScriptDynamic } from "nativescript-angular/platform";
+                import { CustomModule } from "./custom/custom.module";
+                platformNativeScriptDynamic().bootstrapModule(CustomModule);
+            `,
             transformedFile: `
-                    ${handleHmrPlatformDynamicImport}
-                    import { CustomModule } from "./custom/custom.module";
+                ${handleHmrPlatformDynamicImport}
+                import { CustomModule } from "./custom/custom.module";
 
-                    ${handleHmrOptionsDeclaration}
-                    ${getHandleHmrOptionsCode("CustomModule", "./custom/custom.module")}
-                    ${getAcceptMainModuleCode("./custom/custom.module")}
+                ${handleHmrOptionsDeclaration}
+                ${getHmrOptionsCode("CustomModule", "./custom/custom.module")}
+                ${getAcceptMainModuleCode("./custom/custom.module")}
 
-                    ${nsDynamicPlatformCall}(${GeneratedDynamicAppOptions}).bootstrapModule(CustomModule);
-                `,
+                ${nsDynamicPlatformCall}(${defaultAppOptions}).bootstrapModule(CustomModule);
+            `,
             transformedFileWithAot: `
-                    ${handleHmrPlatformStaticImport}
-                    ${handleAotPlatformStaticImport}
-                    ${handleAotNgFactoryImport}
+                ${handleHmrPlatformStaticImport}
+                ${handleAotPlatformStaticImport}
+                ${handleAotNgFactoryImport}
 
-                    ${handleHmrOptionsDeclaration}
-                    ${getHandleHmrOptionsCode("CustomModuleNgFactory", "./test-file.ts.ngfactory")}
-                    ${getAcceptMainModuleCode("./test-file.ts.ngfactory")}
+                ${handleHmrOptionsDeclaration}
+                ${getHmrOptionsCode("CustomModuleNgFactory", "./test-file.ts.ngfactory")}
+                ${getAcceptMainModuleCode("./test-file.ts.ngfactory")}
 
-                    ${nsStaticPlatformCall}(${GeneratedDynamicAppOptions}).bootstrapModuleFactory(${nsFactoryImportName}.CustomModuleNgFactory);
-                `
+                ${nsStaticPlatformCall}(${defaultAppOptions}).bootstrapModuleFactory(${nsFactoryImportName}.CustomModuleNgFactory);
+            `
         },
         {
             name: "should handle HMR when platformNativeScriptDynamic is called from * import",
             rawFile: `
-                    import * as nsNgPlatform from "nativescript-angular/platform";
-                    import { AppModule } from "./app/app.module";
-                    nsNgPlatform.platformNativeScriptDynamic().bootstrapModule(AppModule);
-                `,
+                import * as nsNgPlatform from "nativescript-angular/platform";
+                import { AppModule } from "./app/app.module";
+                nsNgPlatform.platformNativeScriptDynamic().bootstrapModule(AppModule);
+            `,
             transformedFile: `
-                    ${handleHmrPlatformDynamicImport}
-                    import { AppModule } from "./app/app.module";
+                ${handleHmrPlatformDynamicImport}
+                import { AppModule } from "./app/app.module";
 
-                    ${handleHmrOptionsDeclaration}
-                    ${handleHmrOptionsCode}
-                    ${acceptMainModuleCode}
+                ${handleHmrOptionsDeclaration}
+                ${handleHmrOptionsCode}
+                ${acceptMainModuleCode}
 
-                    ${nsDynamicPlatformCall}(${GeneratedDynamicAppOptions}).bootstrapModule(AppModule);
-                `,
+                ${nsDynamicPlatformCall}(${defaultAppOptions}).bootstrapModule(AppModule);
+            `,
             transformedFileWithAot: `
-                    ${handleHmrPlatformStaticImport}
-                    ${handleAotPlatformStaticImport}
-                    ${handleAotNgFactoryImport}
+                ${handleHmrPlatformStaticImport}
+                ${handleAotPlatformStaticImport}
+                ${handleAotNgFactoryImport}
 
-                    ${handleHmrOptionsDeclaration}
-                    ${handleHmrOptionsAotCode}
-                    ${acceptMainModuleAotCode}
+                ${handleHmrOptionsDeclaration}
+                ${handleHmrOptionsAotCode}
+                ${acceptMainModuleAotCode}
 
-                    ${nsStaticPlatformCall}(${GeneratedDynamicAppOptions}).bootstrapModuleFactory(${nsFactoryImportName}.AppModuleNgFactory);
-                `
+                ${nsStaticPlatformCall}(${defaultAppOptions}).bootstrapModuleFactory(${nsFactoryImportName}.AppModuleNgFactory);
+            `
         },
         {
             name: "should handle HMR when platformNativeScriptDynamic is called with inline appOptions",
             rawFile: `
-                    import { platformNativeScriptDynamic } from "nativescript-angular/platform";
-                    import { AppModule } from "./app/app.module";
-                    platformNativeScriptDynamic({ bootInExistingPage: true }).bootstrapModule(AppModule);
-                `,
+                import { platformNativeScriptDynamic } from "nativescript-angular/platform";
+                import { AppModule } from "./app/app.module";
+                platformNativeScriptDynamic({ bootInExistingPage: true }).bootstrapModule(AppModule);
+            `,
             transformedFile: `
-                    ${handleHmrPlatformDynamicImport}
-                    import { AppModule } from "./app/app.module";
+                ${handleHmrPlatformDynamicImport}
+                import { AppModule } from "./app/app.module";
 
-                    var ${GeneratedDynamicAppOptions} = { bootInExistingPage: true };
-                    ${handleHmrOptionsCode}
-                    ${acceptMainModuleCode}
+                ${handleHmrOptionsDeclaration}
+                ${handleHmrOptionsCode}
+                ${acceptMainModuleCode}
 
-                    ${nsDynamicPlatformCall}(${GeneratedDynamicAppOptions}).bootstrapModule(AppModule);
-                `,
+                ${nsDynamicPlatformCall}(${getAppOptions("{ bootInExistingPage: true }")}).bootstrapModule(AppModule);
+            `,
             transformedFileWithAot: `
-                    ${handleHmrPlatformStaticImport}
-                    ${handleAotPlatformStaticImport}
-                    ${handleAotNgFactoryImport}
+                ${handleHmrPlatformStaticImport}
+                ${handleAotPlatformStaticImport}
+                ${handleAotNgFactoryImport}
 
-                    var ${GeneratedDynamicAppOptions} = { bootInExistingPage: true };
-                    ${handleHmrOptionsAotCode}
-                    ${acceptMainModuleAotCode}
+                ${handleHmrOptionsDeclaration}
+                ${handleHmrOptionsAotCode}
+                ${acceptMainModuleAotCode}
 
-                    ${nsStaticPlatformCall}(${GeneratedDynamicAppOptions}).bootstrapModuleFactory(${nsFactoryImportName}.AppModuleNgFactory);
-                `
+                ${nsStaticPlatformCall}(${getAppOptions("{ bootInExistingPage: true }")}).bootstrapModuleFactory(${nsFactoryImportName}.AppModuleNgFactory);
+            `
         },
+        {
+            name: "should handle HMR when platformNativeScriptDynamic is called with appOptions variable",
+            rawFile: `
+                import { platformNativeScriptDynamic } from "nativescript-angular/platform";
+                import { AppModule } from "./app/app.module";
+                const appOptions = { bootInExistingPage: true };
+                platformNativeScriptDynamic(appOptions).bootstrapModule(AppModule);
+            `,
+            transformedFile: `
+                ${handleHmrPlatformDynamicImport}
+                import { AppModule } from "./app/app.module";
+
+                var ${GeneratedDynamicAppOptions} = {};
+                ${handleHmrOptionsCode}
+                ${acceptMainModuleCode}
+
+                const appOptions = { bootInExistingPage: true };
+                
+                ${nsDynamicPlatformCall}(${getAppOptions("appOptions")}).bootstrapModule(AppModule);
+            `,
+            transformedFileWithAot: `
+                ${handleHmrPlatformStaticImport}
+                ${handleAotPlatformStaticImport}
+                ${handleAotNgFactoryImport}
+
+                var ${GeneratedDynamicAppOptions} = {};
+                ${handleHmrOptionsAotCode}
+                ${acceptMainModuleAotCode}
+
+                const appOptions = { bootInExistingPage: true };
+                
+                ${nsStaticPlatformCall}(${getAppOptions("appOptions")}).bootstrapModuleFactory(${nsFactoryImportName}.AppModuleNgFactory);
+            `
+        },
+
         {
             name: "should handle HMR when platformNativeScriptDynamic is called with multiple arguments",
             rawFile: `
-                    import { platformNativeScriptDynamic } from "nativescript-angular/platform";
-                    import { AppModule } from "./app/app.module";
-                    platformNativeScriptDynamic({ bootInExistingPage: true }, ["provider1", "provider2"]).bootstrapModule(AppModule);
-                `,
+                        import { platformNativeScriptDynamic } from "nativescript-angular/platform";
+                        import { AppModule } from "./app/app.module";
+                        platformNativeScriptDynamic({ bootInExistingPage: true }, ["provider1", "provider2"]).bootstrapModule(AppModule);
+                    `,
             transformedFile: `
-                    ${handleHmrPlatformDynamicImport}
-                    import { AppModule } from "./app/app.module";
+                        ${handleHmrPlatformDynamicImport}
+                        import { AppModule } from "./app/app.module";
 
-                    var ${GeneratedDynamicAppOptions} = { bootInExistingPage: true };
-                    ${handleHmrOptionsCode}
-                    ${acceptMainModuleCode}
+                        ${handleHmrOptionsDeclaration}
+                        ${handleHmrOptionsCode}
+                        ${acceptMainModuleCode}
 
-                    ${nsDynamicPlatformCall}(${GeneratedDynamicAppOptions}, ["provider1", "provider2"]).bootstrapModule(AppModule);
-                `,
+                        ${nsDynamicPlatformCall}(${getAppOptions("{ bootInExistingPage: true }")}, ["provider1", "provider2"]).bootstrapModule(AppModule);
+                    `,
             transformedFileWithAot: `
-                    ${handleHmrPlatformStaticImport}
-                    ${handleAotPlatformStaticImport}
-                    ${handleAotNgFactoryImport}
+                        ${handleHmrPlatformStaticImport}
+                        ${handleAotPlatformStaticImport}
+                        ${handleAotNgFactoryImport}
 
-                    var ${GeneratedDynamicAppOptions} = { bootInExistingPage: true };
-                    ${handleHmrOptionsAotCode}
-                    ${acceptMainModuleAotCode}
+                        ${handleHmrOptionsDeclaration}
+                        ${handleHmrOptionsAotCode}
+                        ${acceptMainModuleAotCode}
 
-                    ${nsStaticPlatformCall}(${GeneratedDynamicAppOptions}, ["provider1", "provider2"]).bootstrapModuleFactory(${nsFactoryImportName}.AppModuleNgFactory);
-                `
+                        ${nsStaticPlatformCall}(${getAppOptions("{ bootInExistingPage: true }")}, ["provider1", "provider2"]).bootstrapModuleFactory(${nsFactoryImportName}.AppModuleNgFactory);
+                    `
         },
         {
             name: "should accept HMR before the user when custom handling is in place",
             rawFile: `
-                    import { platformNativeScriptDynamic } from "nativescript-angular/platform";
-                    import { AppModule } from "./app/app.module";
+                        import { platformNativeScriptDynamic } from "nativescript-angular/platform";
+                        import { AppModule } from "./app/app.module";
 
-                    if (module["hot"]) {
-                        module["hot"].accept(["./app/app.module"], function () {
-                            // customHandling
-                        });
-                    }
+                        if (module["hot"]) {
+                            module["hot"].accept(["./app/app.module"], function () {
+                                // customHandling
+                            });
+                        }
 
-                    platformNativeScriptDynamic().bootstrapModule(AppModule);
-                `,
+                        platformNativeScriptDynamic().bootstrapModule(AppModule);
+                    `,
             transformedFile: `
-                    ${handleHmrPlatformDynamicImport}
-                    import { AppModule } from "./app/app.module";
+                        ${handleHmrPlatformDynamicImport}
+                        import { AppModule } from "./app/app.module";
 
-                    ${handleHmrOptionsDeclaration}
-                    ${handleHmrOptionsCode}
-                    ${acceptMainModuleCode}
+                        ${handleHmrOptionsDeclaration}
+                        ${handleHmrOptionsCode}
+                        ${acceptMainModuleCode}
 
-                    if (module["hot"]) {
-                        module["hot"].accept(["./app/app.module"], function () {
-                            // customHandling
-                        });
-                    }
+                        if (module["hot"]) {
+                            module["hot"].accept(["./app/app.module"], function () {
+                                // customHandling
+                            });
+                        }
 
-                    ${nsDynamicPlatformCall}(${GeneratedDynamicAppOptions}).bootstrapModule(AppModule);
-                `,
+                        ${nsDynamicPlatformCall}(${defaultAppOptions}).bootstrapModule(AppModule);
+                    `,
             transformedFileWithAot: `
-                    ${handleHmrPlatformStaticImport}
-                    ${handleAotPlatformStaticImport}
-                    ${handleAotNgFactoryImport}
+                        ${handleHmrPlatformStaticImport}
+                        ${handleAotPlatformStaticImport}
+                        ${handleAotNgFactoryImport}
 
-                    ${handleHmrOptionsDeclaration}
-                    ${handleHmrOptionsAotCode}
-                    ${acceptMainModuleAotCode}
+                        ${handleHmrOptionsDeclaration}
+                        ${handleHmrOptionsAotCode}
+                        ${acceptMainModuleAotCode}
 
-                    if (module["hot"]) {
-                        module["hot"].accept(["./app/app.module"], function () {
-                            // customHandling
-                        });
-                    }
+                        if (module["hot"]) {
+                            module["hot"].accept(["./app/app.module"], function () {
+                                // customHandling
+                            });
+                        }
 
-                    ${nsStaticPlatformCall}(${GeneratedDynamicAppOptions}).bootstrapModuleFactory(${nsFactoryImportName}.AppModuleNgFactory);
-                `
+                        ${nsStaticPlatformCall}(${defaultAppOptions}).bootstrapModuleFactory(${nsFactoryImportName}.AppModuleNgFactory);
+                    `
         }
         ];
         testCases.forEach((testCase: any) => {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [x] Tests for the changes are included.

## What is the current behavior?
A runtime exception is thrown when you bootstrap your Angular app using a variable as App options like:
`const appOptions = { bootInExistingPage: true };
platformNativeScriptDynamic(appOptions).bootstrapModule(AppModule);`

## What is the new behavior?
The case is properly handled and covered by an unit test.