### PR TITLE
fix: show message for stopping webpack only when it has been started

### DIFF
--- a/lib/after-watch.js
+++ b/lib/after-watch.js
@@ -2,8 +2,7 @@ const { stopWebpackCompiler } = require('./compiler');
 const { removeListener } = require("./utils");
 
 module.exports = function($logger, $liveSyncService) {
-    $logger.info("Stopping webpack watch");
-    stopWebpackCompiler();
+    stopWebpackCompiler($logger);
     removeListener($liveSyncService, "liveSyncStopped");
     removeListener(process, "exit");
 }

--- a/lib/before-watch.js
+++ b/lib/before-watch.js
@@ -10,11 +10,11 @@ module.exports = function ($logger, $liveSyncService, $devicesService, hookArgs)
                 Object.keys(webpackProcesses).forEach(platform => {
                     const devices = $devicesService.getDevicesForPlatform(platform);
                     if (!devices || !devices.length) {
-                        stopWebpackCompiler(platform);
+                        stopWebpackCompiler($logger, platform);
                     }
                 });
             });
-            addListener(process, "exit", stopWebpackCompiler);
+            addListener(process, "exit", () => stopWebpackCompiler($logger));
 
             const platforms = hookArgs.config.platforms;
             return Promise.all(platforms.map(platform => {

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -123,11 +123,11 @@ exports.runWebpackCompiler = function runWebpackCompiler(config, $projectData, $
     }
 }
 
-exports.stopWebpackCompiler = function stopWebpackCompiler(platform) {
+exports.stopWebpackCompiler = function stopWebpackCompiler($logger, platform) {
     if (platform) {
-        stopWebpackForPlatform(platform);
+        stopWebpackForPlatform($logger, platform);
     } else {
-        Object.keys(webpackProcesses).forEach(platform => stopWebpackForPlatform(platform));
+        Object.keys(webpackProcesses).forEach(platform => stopWebpackForPlatform($logger, platform));
     }
 }
 
@@ -171,9 +171,11 @@ function logSnapshotWarningMessage($logger) {
     }
 }
 
-function stopWebpackForPlatform(platform) {
+function stopWebpackForPlatform($logger, platform) {
+    $logger.trace(`Stopping webpack watch for platform ${platform}.`);
     const webpackProcess = webpackProcesses[platform];
     webpackProcess.kill("SIGINT");
+
     delete webpackProcesses[platform];
 }
 


### PR DESCRIPTION
Currently the message `Stopping webpack watch` is printed whenever CLI executes `after-watch` hooks, i.e. when user runs `tns run <platform>` and sends Ctrl+C, the message is shown. However, we have not started any webpack process, so there's nothing to stop.
Print the message only when webpack process had been started. Also print it only when `--log trace` is used.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [x] Tests for the changes are included.

## What is the current behavior?
Message `Stopping webpack watch`  is shown when you execute `tns run <platform>` (without `--bundle`) and press `Ctrl + C`.

## What is the new behavior?
Message `Stopping webpack watch`  is shown only when you execute `tns run <platform> --bundle` and press `Ctrl + C`.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla