### PR TITLE
fix: fix "Cannot read property 'kill' of undefined" error

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -173,7 +173,9 @@ function logSnapshotWarningMessage($logger) {
 
 function stopWebpackForPlatform(platform) {
     const webpackProcess = webpackProcesses[platform];
-    webpackProcess.kill("SIGINT");
-    delete webpackProcesses[platform];
+    if (webpackProcess) {
+        webpackProcess.kill("SIGINT");
+        delete webpackProcesses[platform];
+    }
 }
 


### PR DESCRIPTION
`Cannot read property 'kill' of undefined` error is thrown when `ctrl+c` is pressed immediately after webpack process is started and still is not persisted

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
`Cannot read property 'kill' of undefined` error is thrown when `ctrl+c` is pressed immediately after webpack process is started and still is not persisted

## What is the new behavior?

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla