### PR TITLE
feat: Support Angular Ivy modules with AOT

### DIFF
--- a/transformers/ns-replace-bootstrap.spec.ts
+++ b/transformers/ns-replace-bootstrap.spec.ts
@@ -34,6 +34,38 @@ describe('@ngtools/webpack transformers', () => {
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
     });
 
+    it('should replace bootstrap and don`t use factories when Ivy is enabled', () => {
+      const input = tags.stripIndent`
+        import { platformNativeScriptDynamic } from "nativescript-angular/platform";
+        import { AppModule } from "./app/app.module";
+
+        platformNativeScriptDynamic().bootstrapModule(AppModule);
+      `;
+
+      const output = tags.stripIndent`
+        import * as __NgCli_bootstrap_1_1 from "nativescript-angular/platform-static";
+        import * as __NgCli_bootstrap_2_1 from "./app/app.module";
+
+        __NgCli_bootstrap_1_1.platformNativeScript().bootstrapModule(__NgCli_bootstrap_2_1.AppModule);
+      `;
+
+      const { program, compilerHost } = createTypescriptContext(input);
+      const ngCompiler: any = {
+        _compilerOptions: {
+          enableIvy: true
+        },
+        typeChecker: program.getTypeChecker(),
+        entryModule: {
+          path: '/project/src/app/app.module',
+          className: 'AppModule',
+        },
+      };
+      const transformer = nsReplaceBootstrap(() => ngCompiler);
+      const result = transformTypescript(undefined, [transformer], program, compilerHost);
+
+      expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+    });
+
     it('should replace bootstrap when barrel files are used', () => {
       const input = tags.stripIndent`
         import { platformNativeScriptDynamic } from "nativescript-angular/platform";


### PR DESCRIPTION
The changes are based on the ones in the Angular CLI - https://github.com/angular/angular-cli/commit/7347d881925130ce325009588b20d5b39ac73258#diff-6b9947d457bac2310a5d25e102697423R85


## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [x] Tests for the changes are included.

## What is the current behavior?
The AOT transformer is always changing the bootstrap call to `bootstrapModuleFactory` which is not valid for Ivy compatible modules.

## What is the new behavior?
The transformer is using `bootstrapModule` or `bootstrapModuleFactory` based on the `enableIvy` flag.

Connected to https://github.com/NativeScript/nativescript-dev-webpack/issues/827