### PR TITLE
fix: execute bundle-config-loader only for the entry point of the application

### DIFF
--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -177,7 +177,7 @@ module.exports = env => {
         module: {
             rules: [
                 {
-                    test: new RegExp(entryPath),
+                    test: new RegExp(join(appFullPath, entryPath)),
                     use: [
                         // Require all Android app components
                         platform === "android" && {

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -139,7 +139,7 @@ module.exports = env => {
         module: {
             rules: [
                 {
-                    test: new RegExp(entryPath),
+                    test: new RegExp(join(appFullPath, entryPath)),
                     use: [
                         // Require all Android app components
                         platform === "android" && {

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -141,7 +141,7 @@ module.exports = env => {
         module: {
             rules: [
                 {
-                    test: new RegExp(entryPath),
+                    test: new RegExp(join(appFullPath, entryPath)),
                     use: [
                         // Require all Android app components
                         platform === "android" && {

--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -1,4 +1,4 @@
-const { relative, resolve, sep } = require("path");
+const { join, relative, resolve, sep } = require("path");
 
 const webpack = require("webpack");
 const CleanWebpackPlugin = require("clean-webpack-plugin");

--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -151,7 +151,7 @@ module.exports = env => {
         },
         module: {
             rules: [{
-                    test: new RegExp(entryPath + ".(js|ts)"),
+                    test: new RegExp(join(appFullPath, entryPath + ".(js|ts)")),
                     use: [
                         // Require all Android app components
                         platform === "android" && {


### PR DESCRIPTION
Currently bundle-config-loader is executed for any file of the application with the same name as main entry file. For example if the javascript application has app.js file located in `./app/some-folder/app.js`, the bundle-config-loader will be executed for this file.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
`bundle-config-loader` is executed for any file of the application with the same name as main entry file

## What is the new behavior?
`bundle-config-loader` is executed only for the entry point of the application

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla