### PR TITLE
chore: entryPath check should work on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,12 @@ exports.getAppPath = (platform, projectDir) => {
     }
 };
 
+exports.getEntryPathRegExp = (appFullPath, entryModule) => {
+    const entryModuleFullPath = path.join(appFullPath, entryModule);
+    // Windows paths contain `\`, so we need to convert each of the `\` to `\\`, so it will be correct inside RegExp
+    const escapedPath = entryModuleFullPath.replace(/\\/g, "\\\\");
+    return new RegExp(escapedPath);
+}
 /**
  * Converts an array of strings externals to an array of regular expressions.
  * Input is an array of string, which we need to convert to regular expressions, so all imports for this module will be treated as externals.

--- a/index.spec.ts
+++ b/index.spec.ts
@@ -1,4 +1,5 @@
-import { getConvertedExternals } from './index';
+import { getConvertedExternals, getEntryPathRegExp } from './index';
+const path = require("path");
 
 describe('index', () => {
     describe('getConvertedExternals', () => {
@@ -49,6 +50,29 @@ describe('index', () => {
                     expect(result).toBe(false, `String ${testString} matches some of the regular expressions: ${regExpsExternals.join(', ')}`);
                 });
             });
+        });
+    });
+
+    describe('getEntryPathRegExp', () => {
+        const originalPathJoin = path.join;
+        const entryModule = "index.js";
+
+        afterEach(() => {
+            path.join = originalPathJoin;
+        });
+
+        it('returns RegExp that matches Windows', () => {
+            const appPath = "D:\\Work\\app1\\app";
+            path.join = path.win32.join;
+            const regExp = getEntryPathRegExp(appPath, entryModule);
+            expect(!!regExp.exec(`${appPath}\\${entryModule}`)).toBe(true);
+        });
+
+        it('returns RegExp that works with POSIX paths', () => {
+            const appPath = "/usr/local/lib/app1/app";
+            path.join = path.posix.join;
+            const regExp = getEntryPathRegExp(appPath, entryModule);
+            expect(!!regExp.exec(`${appPath}/${entryModule}`)).toBe(true);
         });
     });
 });

--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -180,7 +180,7 @@ module.exports = env => {
         module: {
             rules: [
                 {
-                    test: new RegExp(join(appFullPath, entryPath)),
+                    test: nsWebpack.getEntryPathRegExp(appFullPath, entryPath),
                     use: [
                         // Require all Android app components
                         platform === "android" && {

--- a/templates/webpack.config.spec.ts
+++ b/templates/webpack.config.spec.ts
@@ -21,6 +21,7 @@ const nativeScriptDevWebpack = {
     getAppPath: () => 'app',
     getEntryModule: () => 'EntryModule',
     getResolver: () => null,
+    getEntryPathRegExp: () => null,
     getConvertedExternals: nsWebpackIndex.getConvertedExternals
 };
 

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -142,7 +142,7 @@ module.exports = env => {
         module: {
             rules: [
                 {
-                    test: new RegExp(join(appFullPath, entryPath)),
+                    test: nsWebpack.getEntryPathRegExp(appFullPath, entryPath),
                     use: [
                         // Require all Android app components
                         platform === "android" && {

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -144,7 +144,7 @@ module.exports = env => {
         module: {
             rules: [
                 {
-                    test: new RegExp(join(appFullPath, entryPath)),
+                    test: nsWebpack.getEntryPathRegExp(appFullPath, entryPath),
                     use: [
                         // Require all Android app components
                         platform === "android" && {

--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -155,7 +155,7 @@ module.exports = env => {
         },
         module: {
             rules: [{
-                    test: new RegExp(join(appFullPath, entryPath + ".(js|ts)")),
+                    test: nsWebpack.getEntryPathRegExp(appFullPath, entryPath + ".(js|ts)"),
                     use: [
                         // Require all Android app components
                         platform === "android" && {


### PR DESCRIPTION
In a previous commit we've changed the check when to execute the `bundle-config-loader` to be based on full path. However, the created RegExp does not match anything on Windows as the paths contain `\`, which are used for escape symbol inside RegExp.
Escape the `\` and update all webpack configs with the new RegExp.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [x] Tests for the changes are included.

## What is the current behavior?
Application built with Webpack on Windows fail at runtime.

## What is the new behavior?
You can build applications with Webpack on all OSes.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla