### PR TITLE
fix: support platform specific files that are not directly imported anywhere in the app

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,14 +25,21 @@ exports.getAotEntryModule = function (appDirectory) {
     return aotEntry;
 }
 
-exports.getEntryModule = function (appDirectory) {
+exports.getEntryModule = function (appDirectory, platform) {
     verifyEntryModuleDirectory(appDirectory);
 
     const entry = getPackageJsonEntry(appDirectory);
 
     const tsEntryPath = path.resolve(appDirectory, `${entry}.ts`);
     const jsEntryPath = path.resolve(appDirectory, `${entry}.js`);
-    if (!existsSync(tsEntryPath) && !existsSync(jsEntryPath)) {
+    let entryExists = existsSync(tsEntryPath) || existsSync(jsEntryPath);
+    if (!entryExists && platform) {
+        const platformTsEntryPath = path.resolve(appDirectory, `${entry}.${platform}.ts`);
+        const platformJsEntryPath = path.resolve(appDirectory, `${entry}.${platform}.js`);
+        entryExists = existsSync(platformTsEntryPath) || existsSync(platformJsEntryPath);
+    }
+
+    if (!entryExists) {
         throw new Error(`The entry module ${entry} specified in ` +
             `${appDirectory}/package.json doesn't exist!`)
     }

--- a/package.json
+++ b/package.json
@@ -100,6 +100,8 @@
   },
   "devDependencies": {
     "@ngtools/webpack": "~7.2.0",
+    "@angular/compiler": "~7.2.0",
+    "@angular/compiler-cli": "~7.2.0",
     "@types/jasmine": "^3.3.7",
     "@types/node": "^10.12.12",
     "@types/proxyquire": "1.3.28",

--- a/plugins/NativeScriptAngularCompilerPlugin.ts
+++ b/plugins/NativeScriptAngularCompilerPlugin.ts
@@ -1,0 +1,28 @@
+import { parse, sep } from "path";
+import { AngularCompilerPlugin } from "@ngtools/webpack";
+
+export function getAngularCompilerPlugin(platform: string): any {
+    class NativeScriptAngularCompilerPlugin extends AngularCompilerPlugin {
+        // This is the bridge between the @ngtols/webpack loader and the AngularCompilerPlugin plugin itself:
+        // https://github.com/angular/angular-cli/blob/bf52b26219ffc16bed2dd55716e21773b415fd2a/packages/ngtools/webpack/src/loader.ts#L49
+        // The problem is that the loader does not call the `hostReplacementPaths` method when asking for the compiledFile.
+        // By overriding this method, we workaround this issue and support platform specific files from the loader 
+        // that are not compiled by the AngularCompilerPlugin plugin. e.g. main.ts is the webpack entry point and
+        // it's loaded by the @ngtools/webpack loader but its not compiled by the plugin because the TypeScript Compiler
+        // knowns only about main.android.ts and main.ios.ts (main.ts is not imported/required anywhere in the app).
+        getCompiledFile(file) {
+            try {
+                if (platform) {
+                    const parsed = parse(file);
+                    const platformFile = parsed.dir + sep + parsed.name + "." + platform + parsed.ext;
+                    return super.getCompiledFile(platformFile);;
+                }
+            }
+            catch (e) { }
+
+            return super.getCompiledFile(file);
+        }
+    }
+
+    return NativeScriptAngularCompilerPlugin;
+}

--- a/plugins/NativeScriptAngularCompilerPlugin.ts
+++ b/plugins/NativeScriptAngularCompilerPlugin.ts
@@ -1,4 +1,4 @@
-import { parse, sep } from "path";
+import { parse, join } from "path";
 import { AngularCompilerPlugin } from "@ngtools/webpack";
 
 export function getAngularCompilerPlugin(platform: string): any {
@@ -6,7 +6,7 @@ export function getAngularCompilerPlugin(platform: string): any {
         // This is the bridge between the @ngtols/webpack loader and the AngularCompilerPlugin plugin itself:
         // https://github.com/angular/angular-cli/blob/bf52b26219ffc16bed2dd55716e21773b415fd2a/packages/ngtools/webpack/src/loader.ts#L49
         // The problem is that the loader does not call the `hostReplacementPaths` method when asking for the compiledFile.
-        // By overriding this method, we workaround this issue and support platform specific files from the loader 
+        // By overriding this method, we work around this issue and support platform specific files from the loader 
         // that are not compiled by the AngularCompilerPlugin plugin. e.g. main.ts is the webpack entry point and
         // it's loaded by the @ngtools/webpack loader but its not compiled by the plugin because the TypeScript Compiler
         // knowns only about main.android.ts and main.ios.ts (main.ts is not imported/required anywhere in the app).
@@ -14,8 +14,8 @@ export function getAngularCompilerPlugin(platform: string): any {
             try {
                 if (platform) {
                     const parsed = parse(file);
-                    const platformFile = parsed.dir + sep + parsed.name + "." + platform + parsed.ext;
-                    return super.getCompiledFile(platformFile);;
+                    const platformFile = join(parsed.dir, `${parsed.name}.${platform}${parsed.ext}`);
+                    return super.getCompiledFile(platformFile);
                 }
             }
             catch (e) { }

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -3,5 +3,6 @@ module.exports = Object.assign({},
     require("./NativeScriptSnapshotPlugin"),
     require("./PlatformSuffixPlugin"),
     require("./PlatformFSPlugin"),
-    require("./WatchStateLoggerPlugin")
+    require("./WatchStateLoggerPlugin"),
+    require("./NativeScriptAngularCompilerPlugin")
 );

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -3,6 +3,5 @@ module.exports = Object.assign({},
     require("./NativeScriptSnapshotPlugin"),
     require("./PlatformSuffixPlugin"),
     require("./PlatformFSPlugin"),
-    require("./WatchStateLoggerPlugin"),
-    require("./NativeScriptAngularCompilerPlugin")
+    require("./WatchStateLoggerPlugin")
 );

--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -12,8 +12,7 @@ const CopyWebpackPlugin = require("copy-webpack-plugin");
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 const { NativeScriptWorkerPlugin } = require("nativescript-worker-loader/NativeScriptWorkerPlugin");
 const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
-const { AngularCompilerPlugin } = require("@ngtools/webpack");
-const hashSalt =  Date.now().toString();
+const hashSalt = Date.now().toString();
 
 module.exports = env => {
     // Add your custom Activities, Services and other Android app components here.
@@ -27,6 +26,7 @@ module.exports = env => {
         throw new Error("You need to provide a target platform!");
     }
 
+    const AngularCompilerPlugin = nsWebpack.getAngularCompilerPlugin(platform);
     const projectRoot = __dirname;
 
     // Default destination inside platforms/<platform>/...
@@ -261,10 +261,10 @@ module.exports = env => {
                 // configures the WebPack runtime to be generated inside the snapshot
                 // module and no `runtime.js` module exist.
                 (snapshot ? [] : ["./runtime"])
-                .concat([
-                    "./vendor",
-                    "./bundle",
-              ])
+                    .concat([
+                        "./vendor",
+                        "./bundle",
+                    ])
             ),
             // For instructions on how to set up workers with webpack
             // check out https://github.com/nativescript/worker-loader

--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -12,6 +12,7 @@ const CopyWebpackPlugin = require("copy-webpack-plugin");
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 const { NativeScriptWorkerPlugin } = require("nativescript-worker-loader/NativeScriptWorkerPlugin");
 const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
+const { getAngularCompilerPlugin } = require("nativescript-dev-webpack/plugins/NativeScriptAngularCompilerPlugin");
 const hashSalt = Date.now().toString();
 
 module.exports = env => {
@@ -26,7 +27,7 @@ module.exports = env => {
         throw new Error("You need to provide a target platform!");
     }
 
-    const AngularCompilerPlugin = nsWebpack.getAngularCompilerPlugin(platform);
+    const AngularCompilerPlugin = getAngularCompilerPlugin(platform);
     const projectRoot = __dirname;
 
     // Default destination inside platforms/<platform>/...
@@ -54,7 +55,7 @@ module.exports = env => {
     const appFullPath = resolve(projectRoot, appPath);
     const appResourcesFullPath = resolve(projectRoot, appResourcesPath);
     const tsConfigName = "tsconfig.tns.json";
-    const entryModule = `${nsWebpack.getEntryModule(appFullPath)}.ts`;
+    const entryModule = `${nsWebpack.getEntryModule(appFullPath, platform)}.ts`;
     const entryPath = `.${sep}${entryModule}`;
     const entries = { bundle: entryPath };
     if (platform === "ios") {

--- a/templates/webpack.config.spec.ts
+++ b/templates/webpack.config.spec.ts
@@ -22,7 +22,8 @@ const nativeScriptDevWebpack = {
     getEntryModule: () => 'EntryModule',
     getResolver: () => null,
     getEntryPathRegExp: () => null,
-    getConvertedExternals: nsWebpackIndex.getConvertedExternals
+    getConvertedExternals: nsWebpackIndex.getConvertedExternals,
+    getAngularCompilerPlugin: () => AngularCompilerStub
 };
 
 const emptyObject = {};

--- a/templates/webpack.config.spec.ts
+++ b/templates/webpack.config.spec.ts
@@ -22,8 +22,7 @@ const nativeScriptDevWebpack = {
     getEntryModule: () => 'EntryModule',
     getResolver: () => null,
     getEntryPathRegExp: () => null,
-    getConvertedExternals: nsWebpackIndex.getConvertedExternals,
-    getAngularCompilerPlugin: () => AngularCompilerStub
+    getConvertedExternals: nsWebpackIndex.getConvertedExternals
 };
 
 const emptyObject = {};
@@ -37,6 +36,7 @@ const webpackConfigAngular = proxyquire('./webpack.angular', {
     'nativescript-dev-webpack/transformers/ns-replace-lazy-loader': { nsReplaceLazyLoader: () => { return FakeLazyTransformerFlag } },
     'nativescript-dev-webpack/transformers/ns-support-hmr-ng': { nsSupportHmrNg: () => { return FakeHmrTransformerFlag } },
     'nativescript-dev-webpack/utils/ast-utils': { getMainModulePath: () => { return "fakePath"; } },
+    'nativescript-dev-webpack/plugins/NativeScriptAngularCompilerPlugin': { getAngularCompilerPlugin: () => { return AngularCompilerStub; } },
     '@ngtools/webpack': {
         AngularCompilerPlugin: AngularCompilerStub
     }

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -49,7 +49,7 @@ module.exports = env => {
     const appFullPath = resolve(projectRoot, appPath);
     const appResourcesFullPath = resolve(projectRoot, appResourcesPath);
 
-    const entryModule = nsWebpack.getEntryModule(appFullPath);
+    const entryModule = nsWebpack.getEntryModule(appFullPath, platform);
     const entryPath = `.${sep}${entryModule}.js`;
     const entries = { bundle: entryPath };
     if (platform === "ios") {

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -49,7 +49,7 @@ module.exports = env => {
     const appFullPath = resolve(projectRoot, appPath);
     const appResourcesFullPath = resolve(projectRoot, appResourcesPath);
 
-    const entryModule = nsWebpack.getEntryModule(appFullPath);
+    const entryModule = nsWebpack.getEntryModule(appFullPath, platform);
     const entryPath = `.${sep}${entryModule}.ts`;
     const entries = { bundle: entryPath };
     if (platform === "ios") {

--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -56,7 +56,7 @@ module.exports = env => {
     const appFullPath = resolve(projectRoot, appPath);
     const appResourcesFullPath = resolve(projectRoot, appResourcesPath);
 
-    const entryModule = nsWebpack.getEntryModule(appFullPath);
+    const entryModule = nsWebpack.getEntryModule(appFullPath, platform);
     const entryPath = `.${sep}${entryModule}`;
     const entries = { bundle: entryPath };
     if (platform === "ios") {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
If you make your entry point (main.ts) a platform-specific file (main.ios.ts and main.android.ts), the webpack compilation will fail. The compilation also fails when the entry point of a linked plugin is a platform-specific file (take a look at the related issue).

## What is the new behavior?
The platform-specific files are supported entry points of your app and the linked plugins.

Related to: https://github.com/NativeScript/nativescript-dev-webpack/issues/612