### PR TITLE
chore: fix liveSync of html files in Angular apps

### DIFF
--- a/plugins/NativeScriptAngularCompilerPlugin.ts
+++ b/plugins/NativeScriptAngularCompilerPlugin.ts
@@ -6,7 +6,7 @@ export function getAngularCompilerPlugin(platform: string): any {
         // This is the bridge between the @ngtols/webpack loader and the AngularCompilerPlugin plugin itself:
         // https://github.com/angular/angular-cli/blob/bf52b26219ffc16bed2dd55716e21773b415fd2a/packages/ngtools/webpack/src/loader.ts#L49
         // The problem is that the loader does not call the `hostReplacementPaths` method when asking for the compiledFile.
-        // By overriding this method, we work around this issue and support platform specific files from the loader 
+        // By overriding this method, we work around this issue and support platform specific files from the loader
         // that are not compiled by the AngularCompilerPlugin plugin. e.g. main.ts is the webpack entry point and
         // it's loaded by the @ngtools/webpack loader but its not compiled by the plugin because the TypeScript Compiler
         // knowns only about main.android.ts and main.ios.ts (main.ts is not imported/required anywhere in the app).
@@ -15,7 +15,12 @@ export function getAngularCompilerPlugin(platform: string): any {
                 if (platform) {
                     const parsed = parse(file);
                     const platformFile = join(parsed.dir, `${parsed.name}.${platform}${parsed.ext}`);
-                    return super.getCompiledFile(platformFile);
+                    const result = super.getCompiledFile(platformFile);
+                    // In case there's some issue with the generation, getCompilePath may fail or
+                    // produce a result with empty outputText and errorDependencies array populated with files.
+                    if (result && result.outputText) {
+                        return result;
+                    }
                 }
             }
             catch (e) { }


### PR DESCRIPTION
In case you change `.html` file in Angular application, during `tns run <platform> --bundle`, the application will be restarted and an error will be shown.
This happens as in some cases, the `getCompiledFile` method from Angular compiler does not throw an error when it is unable to find a file, but instead it returns an object with empty outputText and array of errors (errorDependencies).
Fix the liveSync in these cases by checking the result of the Angular compiler and fallback to non-platform specific file in the mentioned case.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Unable to use LiveSync in Angular applications.

## What is the new behavior?
LiveSync works in Angular applications.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla