### PR TITLE
fix: fix "ERROR in Must have a source file to refactor." error from ngCompilerPlugin on `test` command

### DIFF
--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -88,7 +88,7 @@ module.exports = env => {
     const ngCompilerPlugin = new AngularCompilerPlugin({
         hostReplacementPaths: nsWebpack.getResolver([platform, "tns"]),
         platformTransformers: ngCompilerTransformers.map(t => t(() => ngCompilerPlugin, resolve(appFullPath, entryModule))),
-        mainPath: resolve(appPath, entryModule),
+        mainPath: join(appFullPath, entryModule),
         tsConfigPath: join(__dirname, tsConfigName),
         skipCodeGeneration: !aot,
         sourceMap: !!sourceMap,


### PR DESCRIPTION
The "ERROR in Must have a source file to refactor." error is thrown when `tns test android --path <projectPath> --bundle` command is executed. 
This error is thrown from `AngularCompilerPlugin` when the path to `main.ts` file is not correct. We provided the path to `main.ts` file [here](https://github.com/NativeScript/nativescript-dev-webpack/blob/dbcfbc2eb97f3907405b1a384e5086f4d6ed8522/templates/webpack.angular.js#L93). As this path is built using `path.resolve` and `appPath` is [relative path](https://github.com/NativeScript/nativescript-dev-webpack/blob/dbcfbc2eb97f3907405b1a384e5086f4d6ed8522/templates/webpack.angular.js#L41), the resulting path is still not an absolute path. In this case NodeJS uses current working directory as described [here](https://nodejs.org/docs/latest/api/path.html#path_path_resolve_paths). In other words, in this case `resolve(appPath, entryModule)` is equal to `join(process.cwd(), appPath, entryModule)`.

NativeScript CLI starts 2 webpack processes on test command - one from [`nativescript-dev-webpack` plugin](https://github.com/NativeScript/nativescript-dev-webpack/blob/dbcfbc2eb97f3907405b1a384e5086f4d6ed8522/lib/compiler.js#L62) and another one from [`karma-webpack` plugin](https://github.com/webpack-contrib/karma-webpack/blob/11cb4fb2af12271bade16915066be47cbc2e85d7/src/karma-webpack.js#L133).
When the webpack process is started from `nativescript-dev-webpack` plugin, cwd is explicitly set [`here`](https://github.com/NativeScript/nativescript-dev-webpack/blob/dbcfbc2eb97f3907405b1a384e5086f4d6ed8522/lib/compiler.js#L67). So, the result from `resolve(appPath, entryModule)` is correct and `AngularCompilerPlugin` is happy.
When the webpack process is started from `karma-webpack` plugin, cwd is not set anywhere, so the default value is used. It is fine and works as expected when `test` command is executed from project directory regardless if `--path` option is provided. It is not fine and the error is thrown in following cases:
*  When `test` command is executed with `--path` option from folder different from project directory
* When `test` command is executed from CI where [cwd](https://github.com/NativeScript/nativescript-tooling-qa/blob/master/core/utils/run.py#L57) is explicitly provided

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla