### PR TITLE
fix: ignore the Webpack runtime chunks when sending HMR updates

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -80,7 +80,7 @@ exports.runWebpackCompiler = function runWebpackCompiler(config, $projectData, $
                         return;
                     }
 
-                    const result = getUpdatedEmittedFiles(message.emittedFiles);
+                    const result = getUpdatedEmittedFiles(message.emittedFiles, message.webpackRuntimeFiles);
 
                     if (hookArgs.hmrData) {
                         hookArgs.hmrData[platform] = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,7 +34,7 @@ function buildEnvData($projectData, platform, env) {
  * if yes this is a HMR update and remove all bundle files as we don't need them to be synced,
  * but only the update chunks
  */
-function getUpdatedEmittedFiles(emittedFiles) {
+function getUpdatedEmittedFiles(emittedFiles, webpackRuntimeFiles) {
     let fallbackFiles = [];
     let hotHash;
     if (emittedFiles.some(x => x.endsWith('.hot-update.json'))) {
@@ -45,6 +45,10 @@ function getUpdatedEmittedFiles(emittedFiles) {
             hotHash = hash;
             // remove bundle/vendor.js files if there's a bundle.XXX.hot-update.js or vendor.XXX.hot-update.js
             result = result.filter(file => file !== `${name}.js`);
+            if (webpackRuntimeFiles && webpackRuntimeFiles.length) {
+                // remove files containing only the Webpack runtime (e.g. runtime.js)
+                result = result.filter(file => webpackRuntimeFiles.indexOf(file) === -1);
+            }
         });
         //if applying of hot update fails, we must fallback to the full files
         fallbackFiles = emittedFiles.filter(file => result.indexOf(file) === -1);

--- a/plugins/WatchStateLoggerPlugin.ts
+++ b/plugins/WatchStateLoggerPlugin.ts
@@ -31,6 +31,7 @@ export class WatchStateLoggerPlugin {
                 console.log(messages.compilationComplete);
             }
 
+            const runtimeOnlyFiles = getWebpackRuntimeOnlyFiles(compilation, compiler);
             let emittedFiles = Object
                 .keys(compilation.assets)
                 .filter(assetKey => compilation.assets[assetKey].emitted);
@@ -42,7 +43,28 @@ export class WatchStateLoggerPlugin {
 
             process.send && process.send(messages.compilationComplete, error => null);
             // Send emitted files so they can be LiveSynced if need be
-            process.send && process.send({ emittedFiles: emittedFilesFakePaths }, error => null);
+            process.send && process.send({ emittedFiles: emittedFilesFakePaths, webpackRuntimeFiles: runtimeOnlyFiles }, error => null);
         });
     }
+}
+
+function getWebpackRuntimeOnlyFiles(compilation, compiler) {
+    let runtimeOnlyFiles = [];
+    try {
+        runtimeOnlyFiles = [].concat(...compilation.chunkGroups
+            // get the chunk group of each entry points (e.g. main.js and inspector-modules.js)
+            .map(chunkGroup => chunkGroup.runtimeChunk)
+            // filter embedded runtime chunks (e.g. part of bundle.js or inspector-modules.js)
+            .filter(runtimeChunk => runtimeChunk.preventIntegration)
+            .map(runtimeChunk => runtimeChunk.files))
+            // get only the unique files in case of "single" runtime (e.g. runtime.js)
+            .filter((value, index, self) => self.indexOf(value) === index)
+            // convert to absolute paths
+            .map(fileName => join(compiler.context, fileName));
+    } catch (e) {
+        // breaking change in the Webpack API
+        console.log("Warning: Unable to find Webpack runtime files.");
+    }
+
+    return runtimeOnlyFiles;
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Take a look at the related issue.

## What is the new behavior?
We are skipping the Webpack runtime chunks when sending files for the HMR updates.

Related to: https://github.com/NativeScript/nativescript-dev-webpack/issues/868