### PR TITLE
fix(hmr): run ts-loader in transpileOnly mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "clean-webpack-plugin": "~1.0.0",
     "copy-webpack-plugin": "~4.6.0",
     "css-loader": "~2.1.1",
+    "fork-ts-checker-webpack-plugin": "^1.2.0",
     "global-modules-path": "2.0.0",
     "minimatch": "3.0.4",
     "nativescript-hook": "0.2.4",


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
See #877

## What is the new behavior?
`ts-loader` running in `transpileOnly` mode with HMR (as [suggested in docs](https://github.com/TypeStrong/ts-loader#hot-module-replacement)). Type-checking assured with [`fork-ts-checker-webpack-plugin`](https://github.com/Realytics/fork-ts-checker-webpack-plugin) (also as suggested in the [`ts-loader` docs](https://github.com/TypeStrong/ts-loader#transpileonly-boolean-defaultfalse))
