### PR TITLE
tests: require mocha as dep before mawesome report

### DIFF
--- a/demo/AngularApp/e2e/setup.ts
+++ b/demo/AngularApp/e2e/setup.ts
@@ -1,4 +1,5 @@
 import { startServer, stopServer, ITestReporter, nsCapabilities, LogImageType } from "nativescript-dev-appium";
+const mochaFake = require("mocha");
 const addContext = require('mochawesome/addContext');
 
 const testReporterContext = <ITestReporter>{};

--- a/demo/JavaScriptApp/e2e/setup.js
+++ b/demo/JavaScriptApp/e2e/setup.js
@@ -1,4 +1,5 @@
 const nsAppium = require("nativescript-dev-appium");
+const mochaFake = require("mocha");
 const addContext = require('mochawesome/addContext');
 
 const testReporterContext = {};

--- a/demo/TypeScriptApp/.gitignore
+++ b/demo/TypeScriptApp/.gitignore
@@ -5,3 +5,4 @@ app/app.android.css
 app/app.ios.css
 app/main-page.android.css
 app/main-page.ios.css
+mochawesome-report

--- a/demo/TypeScriptApp/e2e/setup.ts
+++ b/demo/TypeScriptApp/e2e/setup.ts
@@ -1,4 +1,5 @@
 import { startServer, stopServer, ITestReporter, nsCapabilities, LogImageType } from "nativescript-dev-appium";
+const mochaFake = require("mocha");
 const addContext = require('mochawesome/addContext');
 
 const testReporterContext = <ITestReporter>{};


### PR DESCRIPTION
This is a workaround to make mochawesome to generate reports on windows.