### PR TITLE
chore: freeze fork-ts-checker-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "clean-webpack-plugin": "~1.0.0",
     "copy-webpack-plugin": "~4.6.0",
     "css-loader": "~2.1.1",
-    "fork-ts-checker-webpack-plugin": "^1.2.0",
+    "fork-ts-checker-webpack-plugin": "1.3.0",
     "global-modules-path": "2.0.0",
     "minimatch": "3.0.4",
     "nativescript-hook": "0.2.4",


### PR DESCRIPTION
**Problem**: `fork-ts-checker-webpack-plugin@1.3.1` has a `dependency` to `@types/webpack` which has a `dependency` to `@types/node`.

Because these are direct dependencies you get `@types/node` installed in your NS project which causes problems - clashing node types in NS project.

**Solution**: Freeze the version `freeze fork-ts-checker-webpack-plugin` to `1.3.0` which does not have the  `@types/webpack` dependency. 