### PR TITLE
fix: clean up snpashot tool on download fail (#893)

### DIFF
--- a/snapshot/android/utils.js
+++ b/snapshot/android/utils.js
@@ -12,9 +12,9 @@ const CONSTANTS = {
 
 const createDirectory = dir => mkdir('-p', dir);
 
-const downloadFile = (url, destinationFilePath) =>
+const downloadFile = (url, destinationFilePath, timeout) =>
     new Promise((resolve, reject) => {
-        getRequestOptions(url)
+        getRequestOptions(url, timeout)
             .then(options =>
                 get(options)
                     .on("error", reject)
@@ -49,9 +49,9 @@ const getJsonFile = url =>
             ).catch(reject);
     });
 
-const getRequestOptions = (url) =>
+const getRequestOptions = (url, timeout) =>
     new Promise((resolve, reject) => {
-        const options = { url };
+        const options = { url, timeout };
         getProxySettings()
             .then(proxySettings => {
                 const allOptions = Object.assign(options, proxySettings);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla