### PR TITLE
fix: import the workaroundResolve funciton based on the Angular version (it was moved from compiler_host to utils in Angular 8)

### DIFF
--- a/dependencyManager.js
+++ b/dependencyManager.js
@@ -84,7 +84,7 @@ function getRequiredDeps(packageJson) {
     }
 
     const deps = {
-        "@angular/compiler-cli": "8.0.0-rc.4",
+        "@angular/compiler-cli": "8.0.0-rc.5",
     };
 
     if (!dependsOn(packageJson, "@angular-devkit/build-angular")) {

--- a/dependencyManager.js
+++ b/dependencyManager.js
@@ -84,11 +84,11 @@ function getRequiredDeps(packageJson) {
     }
 
     const deps = {
-        "@angular/compiler-cli": "8.0.0-rc.5",
+        "@angular/compiler-cli": "8.0.0",
     };
 
     if (!dependsOn(packageJson, "@angular-devkit/build-angular")) {
-        deps["@ngtools/webpack"] = "8.0.0-rc.4";
+        deps["@ngtools/webpack"] = "8.0.0";
     }
 
     return deps;

--- a/dependencyManager.js
+++ b/dependencyManager.js
@@ -84,11 +84,11 @@ function getRequiredDeps(packageJson) {
     }
 
     const deps = {
-        "@angular/compiler-cli": "~7.2.0",
+        "@angular/compiler-cli": "8.0.0-rc.4",
     };
 
     if (!dependsOn(packageJson, "@angular-devkit/build-angular")) {
-        deps["@ngtools/webpack"] = "~7.2.0";
+        deps["@ngtools/webpack"] = "8.0.0-rc.4";
     }
 
     return deps;

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "generate-android-snapshot": "./bin/generate-android-snapshot"
   },
   "dependencies": {
-    "@angular-devkit/core": "8.0.0-rc.4",
+    "@angular-devkit/core": "8.0.0",
     "clean-webpack-plugin": "~1.0.0",
     "copy-webpack-plugin": "~4.6.0",
     "css-loader": "~2.1.1",
@@ -101,9 +101,9 @@
     "webpack-sources": "~1.3.0"
   },
   "devDependencies": {
-    "@angular/compiler": "8.0.0-rc.5",
-    "@angular/compiler-cli": "8.0.0-rc.5",
-    "@ngtools/webpack": "8.0.0-rc.4",
+    "@angular/compiler": "8.0.0",
+    "@angular/compiler-cli": "8.0.0",
+    "@ngtools/webpack": "8.0.0",
     "@types/jasmine": "^3.3.7",
     "@types/node": "^10.12.12",
     "@types/proxyquire": "1.3.28",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "generate-android-snapshot": "./bin/generate-android-snapshot"
   },
   "dependencies": {
-    "@angular-devkit/core": "~7.2.0",
+    "@angular-devkit/core": "8.0.0-rc.4",
     "clean-webpack-plugin": "~1.0.0",
     "copy-webpack-plugin": "~4.6.0",
     "css-loader": "~2.1.1",
@@ -89,7 +89,7 @@
     "resolve-url-loader": "~3.0.0",
     "sass-loader": "~7.1.0",
     "schema-utils": "0.4.5",
-    "semver": "5.4.1",
+    "semver": "^6.0.0",
     "shelljs": "0.6.0",
     "tapable": "1.0.0",
     "terser": "3.17.0",
@@ -101,16 +101,17 @@
     "webpack-sources": "~1.3.0"
   },
   "devDependencies": {
-    "@ngtools/webpack": "~7.2.0",
-    "@angular/compiler": "~7.2.0",
-    "@angular/compiler-cli": "~7.2.0",
+    "@angular/compiler": "8.0.0-rc.4",
+    "@angular/compiler-cli": "8.0.0-rc.4",
+    "@ngtools/webpack": "8.0.0-rc.4",
     "@types/jasmine": "^3.3.7",
     "@types/node": "^10.12.12",
     "@types/proxyquire": "1.3.28",
+    "@types/semver": "^6.0.0",
     "conventional-changelog-cli": "^1.3.22",
     "jasmine": "^3.2.0",
     "jasmine-spec-reporter": "^4.2.1",
     "proxyquire": "2.1.0",
-    "typescript": "~3.1.1"
+    "typescript": "~3.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -101,8 +101,8 @@
     "webpack-sources": "~1.3.0"
   },
   "devDependencies": {
-    "@angular/compiler": "8.0.0-rc.4",
-    "@angular/compiler-cli": "8.0.0-rc.4",
+    "@angular/compiler": "8.0.0-rc.5",
+    "@angular/compiler-cli": "8.0.0-rc.5",
     "@ngtools/webpack": "8.0.0-rc.4",
     "@types/jasmine": "^3.3.7",
     "@types/node": "^10.12.12",

--- a/projectHelpers.js
+++ b/projectHelpers.js
@@ -29,6 +29,12 @@ const isAngular = ({ projectDir, packageJson } = {}) => {
         .some(dependency => /^@angular\b/.test(dependency));
 };
 
+const getAngularVersion = ({ projectDir, packageJson } = {}) => {
+    packageJson = packageJson || getPackageJson(projectDir);
+
+    return packageJson.dependencies && packageJson.dependencies["@angular/core"];
+}
+
 const isVue = ({ projectDir, packageJson } = {}) => {
     packageJson = packageJson || getPackageJson(projectDir);
 
@@ -38,7 +44,14 @@ const isVue = ({ projectDir, packageJson } = {}) => {
 
 const getPackageJson = projectDir => {
     const packageJsonPath = getPackageJsonPath(projectDir);
-    return JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+    let result;
+    try {
+        result = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+    } catch (e) {
+        result = {};
+    }
+
+    return result;
 };
 
 const writePackageJson = (content, projectDir) => {
@@ -106,6 +119,7 @@ module.exports = {
     isAndroid,
     isIos,
     isAngular,
+    getAngularVersion,
     isVue,
     isTypeScript,
     writePackageJson,

--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -90,7 +90,7 @@ module.exports = env => {
 
     const ngCompilerPlugin = new AngularCompilerPlugin({
         hostReplacementPaths: nsWebpack.getResolver([platform, "tns"]),
-        platformTransformers: ngCompilerTransformers.map(t => t(() => ngCompilerPlugin, resolve(appFullPath, entryModule))),
+        platformTransformers: ngCompilerTransformers.map(t => t(() => ngCompilerPlugin, resolve(appFullPath, entryModule), projectRoot)),
         mainPath: join(appFullPath, entryModule),
         tsConfigPath: join(__dirname, tsConfigName),
         skipCodeGeneration: !aot,

--- a/transformers/ns-replace-bootstrap.spec.ts
+++ b/transformers/ns-replace-bootstrap.spec.ts
@@ -21,14 +21,16 @@ describe('@ngtools/webpack transformers', () => {
       `;
 
       const { program, compilerHost } = createTypescriptContext(input);
+      const projectDir = "/project/src/";
+      const appModule = `${projectDir}app/app.module`;
       const ngCompiler = <AngularCompilerPlugin>{
         typeChecker: program.getTypeChecker(),
         entryModule: {
-          path: '/project/src/app/app.module',
+          path: appModule,
           className: 'AppModule',
         },
       };
-      const transformer = nsReplaceBootstrap(() => ngCompiler);
+      const transformer = nsReplaceBootstrap(() => ngCompiler, appModule, projectDir);
       const result = transformTypescript(undefined, [transformer], program, compilerHost);
 
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
@@ -50,17 +52,19 @@ describe('@ngtools/webpack transformers', () => {
       `;
 
       const { program, compilerHost } = createTypescriptContext(input);
+      const projectDir = "/project/src/";
+      const appModule = `${projectDir}app/app.module`;
       const ngCompiler: any = {
         _compilerOptions: {
           enableIvy: true
         },
         typeChecker: program.getTypeChecker(),
         entryModule: {
-          path: '/project/src/app/app.module',
+          path: appModule,
           className: 'AppModule',
         },
       };
-      const transformer = nsReplaceBootstrap(() => ngCompiler);
+      const transformer = nsReplaceBootstrap(() => ngCompiler, appModule, projectDir);
       const result = transformTypescript(undefined, [transformer], program, compilerHost);
 
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
@@ -82,14 +86,16 @@ describe('@ngtools/webpack transformers', () => {
       `;
 
       const { program, compilerHost } = createTypescriptContext(input);
+      const projectDir = "/project/src/";
+      const appModule = `${projectDir}app/app.module`;
       const ngCompiler = <AngularCompilerPlugin>{
         typeChecker: program.getTypeChecker(),
         entryModule: {
-          path: '/project/src/app/app.module',
+          path: appModule,
           className: 'AppModule',
         },
       };
-      const transformer = nsReplaceBootstrap(() => ngCompiler);
+      const transformer = nsReplaceBootstrap(() => ngCompiler, appModule, projectDir);
       const result = transformTypescript(undefined, [transformer], program, compilerHost);
 
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
@@ -113,14 +119,16 @@ describe('@ngtools/webpack transformers', () => {
       `;
 
       const { program, compilerHost } = createTypescriptContext(input);
+      const projectDir = "/project/src/";
+      const appModule = `${projectDir}app/app.module`;
       const ngCompiler = <AngularCompilerPlugin>{
         typeChecker: program.getTypeChecker(),
         entryModule: {
-          path: '/project/src/app/app.module',
+          path: appModule,
           className: 'AppModule',
         },
       };
-      const transformer = nsReplaceBootstrap(() => ngCompiler);
+      const transformer = nsReplaceBootstrap(() => ngCompiler, appModule, projectDir);
       const result = transformTypescript(undefined, [transformer], program, compilerHost);
 
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);

--- a/transformers/ns-replace-bootstrap.ts
+++ b/transformers/ns-replace-bootstrap.ts
@@ -15,7 +15,7 @@ import {
 import { AngularCompilerPlugin } from '@ngtools/webpack';
 import { getResolvedEntryModule } from "../utils/transformers-utils";
 
-export function nsReplaceBootstrap(getNgCompiler: () => AngularCompilerPlugin): ts.TransformerFactory<ts.SourceFile> {
+export function nsReplaceBootstrap(getNgCompiler: () => AngularCompilerPlugin, entryPath: string, projectDir: string): ts.TransformerFactory<ts.SourceFile> {
     const shouldTransform = (fileName) => !fileName.endsWith('.ngfactory.ts') && !fileName.endsWith('.ngstyle.ts');
     const getTypeChecker = () => getNgCompiler().typeChecker;
 
@@ -24,7 +24,7 @@ export function nsReplaceBootstrap(getNgCompiler: () => AngularCompilerPlugin): 
         const ngCompiler = getNgCompiler();
         // TODO: use something public when available
         const enableIvy = (<any>ngCompiler)._compilerOptions && (<any>ngCompiler)._compilerOptions.enableIvy;
-        const entryModule = getResolvedEntryModule(ngCompiler);
+        const entryModule = getResolvedEntryModule(ngCompiler, projectDir);
 
         if (!shouldTransform(sourceFile.fileName) || !entryModule) {
             return ops;

--- a/transformers/ns-replace-lazy-loader.spec.ts
+++ b/transformers/ns-replace-lazy-loader.spec.ts
@@ -211,14 +211,16 @@ describe("@ngtools/webpack transformers", () => {
                 const input = tags.stripIndent`${testCase.rawAppModule}`;
                 const output = tags.stripIndent`${testCase.transformedAppModule}`;
                 const { program, compilerHost } = createTypescriptContext(input);
+                const projectDir = "/project/src/";
+                const testFile = `${projectDir}test-file`;
                 const ngCompiler = <AngularCompilerPlugin>{
                     typeChecker: program.getTypeChecker(),
                     entryModule: {
-                        path: "/project/src/test-file",
+                        path: testFile,
                         className: "AppModule",
                     },
                 };
-                const transformer = nsReplaceLazyLoader(() => ngCompiler);
+                const transformer = nsReplaceLazyLoader(() => ngCompiler, testFile, projectDir);
                 const result = transformTypescript(undefined, [transformer], program, compilerHost);
 
                 expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);

--- a/transformers/ns-replace-lazy-loader.ts
+++ b/transformers/ns-replace-lazy-loader.ts
@@ -17,12 +17,12 @@ import { AngularCompilerPlugin } from "@ngtools/webpack";
 import { findIdentifierNode, getObjectPropertyMatches, getDecoratorMetadata } from "../utils/ast-utils";
 import { getResolvedEntryModule } from "../utils/transformers-utils";
 
-export function nsReplaceLazyLoader(getNgCompiler: () => AngularCompilerPlugin): ts.TransformerFactory<ts.SourceFile> {
+export function nsReplaceLazyLoader(getNgCompiler: () => AngularCompilerPlugin, entryPath: string, projectDir: string): ts.TransformerFactory<ts.SourceFile> {
     const getTypeChecker = () => getNgCompiler().typeChecker;
 
-    const standardTransform: StandardTransform = function(sourceFile: ts.SourceFile) {
+    const standardTransform: StandardTransform = function (sourceFile: ts.SourceFile) {
         let ops: TransformOperation[] = [];
-        const entryModule = getResolvedEntryModule(getNgCompiler());
+        const entryModule = getResolvedEntryModule(getNgCompiler(), projectDir);
         const sourceFilePath = join(dirname(sourceFile.fileName), basename(sourceFile.fileName, extname(sourceFile.fileName)));
         if (!entryModule || normalize(sourceFilePath) !== normalize(entryModule.path)) {
             return ops;

--- a/transformers/ns-support-hmr-ng.spec.ts
+++ b/transformers/ns-support-hmr-ng.spec.ts
@@ -351,7 +351,8 @@ describe("@ngtools/webpack transformers", () => {
             });
 
             it(`${testCase.name} (in combination with AOT transformer)`, async () => {
-                const testFile = "/project/src/test-file.ts";
+                const projectDir = "/project/src/";
+                const testFile = `${projectDir}test-file.ts`;
                 const input = tags.stripIndent`${testCase.rawFile}`;
                 const output = tags.stripIndent`${testCase.transformedFileWithAot}`;
                 const { program, compilerHost } = createTypescriptContext(input);
@@ -363,7 +364,7 @@ describe("@ngtools/webpack transformers", () => {
                     },
                 };
 
-                const aotTransformer = nsReplaceBootstrap(() => ngCompiler);
+                const aotTransformer = nsReplaceBootstrap(() => ngCompiler, testFile, projectDir);
                 const hmrTransformer = nsSupportHmrNg(() => ngCompiler, testFile);
                 const result = transformTypescript(undefined, [aotTransformer, hmrTransformer], program, compilerHost);
 

--- a/utils/transformers-utils.ts
+++ b/utils/transformers-utils.ts
@@ -1,8 +1,18 @@
-import { workaroundResolve } from "@ngtools/webpack/src/compiler_host";
 import { AngularCompilerPlugin } from "@ngtools/webpack";
+import * as semver from "semver";
+import { getAngularVersion } from "../projectHelpers";
 
-export function getResolvedEntryModule(ngCompiler: AngularCompilerPlugin) {
+export function getResolvedEntryModule(ngCompiler: AngularCompilerPlugin, projectDir: string) {
+    const ngCoreVersion = projectDir && semver.coerce(getAngularVersion({ projectDir }));
+    let workaroundResolveModule;
+    // https://github.com/angular/angular-cli/commit/d2e22e97818c6582ce4a9942c59fcac4a8aaf60e#diff-0f65e27eb122d9efa58bf08adada7f82L364
+    if (!ngCoreVersion || semver.gte(ngCoreVersion, "8.0.0")) {
+        workaroundResolveModule = require("@ngtools/webpack/src/utils");
+    } else {
+        workaroundResolveModule = require("@ngtools/webpack/src/compiler_host");
+    }
+
     return ngCompiler.entryModule
-        ? { path: workaroundResolve(ngCompiler.entryModule.path), className: ngCompiler.entryModule.className }
+        ? { path: workaroundResolveModule.workaroundResolve(ngCompiler.entryModule.path), className: ngCompiler.entryModule.className }
         : ngCompiler.entryModule;
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
A `workaroundResolve is not a function` error is thrown with Angular 8 (@ngtools/webpack@8.0.0)

## What is the new behavior?
The Angular apps are properly built with Angular 8.

Related to: https://github.com/NativeScript/nativescript-angular/issues/1833 https://github.com/NativeScript/nativescript-angular/pull/1831