### PR TITLE
build(package): Update webpack-bundle-analyzer

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "terser-webpack-plugin": "1.2.3",
     "ts-loader": "^5.3.1",
     "webpack": "~4.27.0",
-    "webpack-bundle-analyzer": "^3.3.2",
+    "webpack-bundle-analyzer": "~3.3.2",
     "webpack-cli": "~3.1.1",
     "webpack-sources": "~1.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "terser-webpack-plugin": "1.2.3",
     "ts-loader": "^5.3.1",
     "webpack": "~4.27.0",
-    "webpack-bundle-analyzer": "~3.0.2",
+    "webpack-bundle-analyzer": "^3.3.2",
     "webpack-cli": "~3.1.1",
     "webpack-sources": "~1.3.0"
   },


### PR DESCRIPTION
Update `webpack-bundle-analyzer` dependency to `3.3.2` to address vulnerability [WS-2019-0058](https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/263)