### PR TITLE
fix: handle relative requests from inside an external module

### DIFF
--- a/index.spec.ts
+++ b/index.spec.ts
@@ -1,7 +1,107 @@
-import { getConvertedExternals, getEntryPathRegExp } from './index';
+import { getConvertedExternals, getEntryPathRegExp, getExternalsHandler } from './index';
 const path = require("path");
 
 describe('index', () => {
+    describe('getExternalsHandler', () => {
+        it('throws an error when the argument is not an array of regular expressions', () => {
+            expect(() => getExternalsHandler()).toThrowError();
+            expect(() => getExternalsHandler(32)).toThrowError();
+            expect(() => getExternalsHandler(null)).toThrowError();
+            expect(() => getExternalsHandler("asd")).toThrowError();
+            expect(() => getExternalsHandler([{}])).toThrowError();
+            expect(() => getExternalsHandler(/((node_modules\/)|^)nativescript-vue((\/.*)|$)/)).toThrowError();
+        });
+
+        const externalContextTestCases = [
+            {
+                name: 'request for another external module from node_modules',
+                input: 'nativescript-angular',
+                expectedIsExternal: true
+            },
+            {
+                name: 'request for the same module from node_modules',
+                input: 'nativescript-vue',
+                expectedIsExternal: true
+            },
+            {
+                name: 'request for a relative file in the same external module',
+                input: './vue-index',
+                expectedIsExternal: true
+            },
+            {
+                name: 'request for a relative file outside the external module',
+                input: '../another-non-external-module/another-index',
+                expectedIsExternal: false
+            },
+            {
+                name: 'request for an absolute local path',
+                input: '/nativescript-vue',
+                expectedIsExternal: false
+            }
+        ];
+
+        externalContextTestCases.forEach(testCase => {
+            it(`returns handler which matches requests inside an external module - ${testCase.name}`, (done) => {
+                const handler = getExternalsHandler([/((node_modules\/)|^)nativescript-vue((\/.*)|$)/, /((node_modules\/)|^)nativescript-angular((\/.*)|$)/]);
+                handler("./node_modules/nativescript-vue/", testCase.input, (error, externalLink) => {
+                    if (testCase.expectedIsExternal) {
+                        expect(error).toBeNull();
+                        expect(externalLink).toBeDefined();
+                    } else {
+                        expect(error).toBeUndefined();
+                        expect(externalLink).toBeUndefined();
+                    }
+                    done();
+                });
+            });
+        });
+
+
+        const nonExternalContextTestCases = [
+            {
+                name: 'request for an external module from node_modules',
+                input: 'nativescript-vue',
+                expectedIsExternal: true
+            },
+            {
+                name: 'request for a relative file from an external module',
+                input: '../node_modules/nativescript-vue/vue-index',
+                expectedIsExternal: true
+            },
+            {
+                name: 'request for a relative file inside the app',
+                input: './app-module',
+                expectedIsExternal: false
+            },
+            {
+                name: 'request for a relative file from a non external module',
+                input: '../node_modules/another-non-external-module/another-index',
+                expectedIsExternal: false
+            },
+            {
+                name: 'request for an absolute local path',
+                input: '/nativescript-vue',
+                expectedIsExternal: false
+            }
+        ];
+
+        nonExternalContextTestCases.forEach(testCase => {
+            it(`returns handler which matches requests from inside the app folder - ${testCase.name}`, (done) => {
+                const handler = getExternalsHandler([/((node_modules\/)|^)nativescript-vue((\/.*)|$)/]);
+                handler("./app/", testCase.input, (error, externalLink) => {
+                    if (testCase.expectedIsExternal) {
+                        expect(error).toBeNull();
+                        expect(externalLink).toBeDefined();
+                    } else {
+                        expect(error).toBeUndefined();
+                        expect(externalLink).toBeUndefined();
+                    }
+                    done();
+                });
+            });
+        });
+    });
+
     describe('getConvertedExternals', () => {
         it('returns empty array when nullable is passed', () => {
             const actualResult = getConvertedExternals(null);
@@ -11,11 +111,11 @@ describe('index', () => {
         const testCases = [
             {
                 input: ['nativescript-vue'],
-                expectedOutput: [/^nativescript-vue((\/.*)|$)/]
+                expectedOutput: [/((node_modules\/)|^)nativescript-vue((\/.*)|$)/]
             },
             {
                 input: ['nativescript-vue', 'nativescript-angular'],
-                expectedOutput: [/^nativescript-vue((\/.*)|$)/, /^nativescript-angular((\/.*)|$)/]
+                expectedOutput: [/((node_modules\/)|^)nativescript-vue((\/.*)|$)/, /((node_modules\/)|^)nativescript-angular((\/.*)|$)/]
             }
         ];
 
@@ -29,6 +129,7 @@ describe('index', () => {
                 [
                     'nativescript-vue',
                     'nativescript-vue/subdir',
+                    './node_modules/nativescript-vue/subdir',
                     'nativescript-vue/subdir/subdir-2'
                 ].forEach(testString => {
                     const regExpsExternals = getConvertedExternals(testCase.input);

--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -103,7 +103,7 @@ module.exports = env => {
     const config = {
         mode: uglify ? "production" : "development",
         context: appFullPath,
-        externals,
+        externals: nsWebpack.getExternalsHandler(externals),
         watchOptions: {
             ignored: [
                 appResourcesFullPath,

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -63,7 +63,7 @@ module.exports = env => {
     const config = {
         mode: uglify ? "production" : "development",
         context: appFullPath,
-        externals,
+        externals: nsWebpack.getExternalsHandler(externals),
         watchOptions: {
             ignored: [
                 appResourcesFullPath,

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -67,7 +67,7 @@ module.exports = env => {
     const config = {
         mode: uglify ? "production" : "development",
         context: appFullPath,
-        externals,
+        externals: nsWebpack.getExternalsHandler(externals),
         watchOptions: {
             ignored: [
                 appResourcesFullPath,

--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -71,7 +71,7 @@ module.exports = env => {
     const config = {
         mode: mode,
         context: appFullPath,
-        externals,
+        externals: nsWebpack.getExternalsHandler(externals),
         watchOptions: {
             ignored: [
                 appResourcesFullPath,


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [x] Tests for the changes are included.

## What is the current behavior?
The Webpack externals logic is matching only the request (the string inside a require or import call), while we need to match both the request and the context when matching relative requests from inside an external module.

## What is the new behavior?
We provide a custom externals handler in order to join the context and the request in such cases.

Related to: https://github.com/NativeScript/nativescript-cli/issues/4658