### PR TITLE
fix: stop generating .d.ts on TS compilation

### DIFF
--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -214,7 +214,8 @@ module.exports = env => {
                             transpileOnly: !!hmr,
                             allowTsInNodeModules: true,
                             compilerOptions: {
-                                sourceMap: isAnySourceMapEnabled
+                                sourceMap: isAnySourceMapEnabled,
+                                declaration: false
                             }
                         },
                     }

--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -209,6 +209,9 @@ module.exports = env => {
                 options: {
                     appendTsSuffixTo: [/\.vue$/],
                     allowTsInNodeModules: true,
+                    compilerOptions: {
+                        declaration: false
+                    }
                 },
             },
             {


### PR DESCRIPTION
In case `declaration` is set to true in `tsconfig.json` file, the webpack watcher goes in indefinite loop as each change of .ts file leads to generation of new .d.ts files which are also detected by webpack.
To prevent this, ensure declaration is set to false in all compilation cases.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [x] Tests for the changes are included.

## What is the current behavior?
Check related issue.

## What is the new behavior?
Transpilation is working correctly.

Fixes issue https://github.com/NativeScript/nativescript-dev-webpack/issues/823

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla