### PR TITLE
fix: handle entry points with custom output filename

### DIFF
--- a/plugins/GenerateNativeScriptEntryPointsPlugin.js
+++ b/plugins/GenerateNativeScriptEntryPointsPlugin.js
@@ -58,7 +58,7 @@ exports.GenerateNativeScriptEntryPointsPlugin = (function () {
                 }
 
                 return requireChunkFiles;
-            }).join("\n");
+            }).join("");
 
         if (entryChunk) {
             entryChunk.files.forEach(fileName => {

--- a/plugins/NativeScriptSnapshotPlugin/index.js
+++ b/plugins/NativeScriptSnapshotPlugin/index.js
@@ -12,7 +12,7 @@ const schema = require("./options.json");
 
 const SNAPSHOT_ENTRY_NAME = "snapshot-entry";
 const SNAPSHOT_ENTRY_MODULE = `${SNAPSHOT_ENTRY_NAME}.js`;
-exports.SNAPSHOT_ENTRY_MODULE = SNAPSHOT_ENTRY_MODULE;
+exports.SNAPSHOT_ENTRY_NAME = SNAPSHOT_ENTRY_NAME;
 
 exports.NativeScriptSnapshotPlugin = (function () {
     function NativeScriptSnapshotPlugin(options) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
When a custom filename is set in the Webpack output property (e.g. output.file…name: "[name].custom.js"), the plugin is throwing an exception.

## What is the new behavior?
The custom filenames are properly handled.
