### PR TITLE
fix: do not include hot updates when generating requires in entry files

### DIFF
--- a/plugins/GenerateNativeScriptEntryPointsPlugin.js
+++ b/plugins/GenerateNativeScriptEntryPointsPlugin.js
@@ -56,7 +56,9 @@ exports.GenerateNativeScriptEntryPointsPlugin = (function () {
                     entryChunk = chunk;
                 } else {
                     chunk.files.forEach(fileName => {
-                        requireChunkFiles += `require("./${fileName}");`;
+                        if (!this.isHMRFile(fileName)) {
+                            requireChunkFiles += `require("./${fileName}");`;
+                        }
                     });
                 }
 
@@ -72,8 +74,10 @@ exports.GenerateNativeScriptEntryPointsPlugin = (function () {
                 throw new Error(`${GenerationFailedError} File "${fileName}" not found for entry "${entryPointName}".`);
             }
 
-            const currentEntryFileContent = compilation.assets[fileName].source();
-            compilation.assets[fileName] = new RawSource(`${requireDeps}${currentEntryFileContent}`);
+            if (!this.isHMRFile(fileName)) {
+                const currentEntryFileContent = compilation.assets[fileName].source();
+                compilation.assets[fileName] = new RawSource(`${requireDeps}${currentEntryFileContent}`);
+            }
         });
     }
 
@@ -82,6 +86,10 @@ exports.GenerateNativeScriptEntryPointsPlugin = (function () {
             this.files[name] = content;
             compilation.assets[name] = new RawSource(content);
         }
+    }
+
+    GenerateNativeScriptEntryPointsPlugin.prototype.isHMRFile = function (fileName) {
+        return fileName.indexOf("hot-update") > -1;
     }
 
     return GenerateNativeScriptEntryPointsPlugin;


### PR DESCRIPTION
They have to be required and processed by the Webpack runtime.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.