### PR TITLE
fix: handle types check in a child process

### DIFF
--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -211,7 +211,9 @@ module.exports = env => {
                         loader: "ts-loader",
                         options: {
                             configFile: tsConfigPath,
-                            transpileOnly: !!hmr,
+                            // https://github.com/TypeStrong/ts-loader/blob/ea2fcf925ec158d0a536d1e766adfec6567f5fb4/README.md#faster-builds
+                            // https://github.com/TypeStrong/ts-loader/blob/ea2fcf925ec158d0a536d1e766adfec6567f5fb4/README.md#hot-module-replacement
+                            transpileOnly: true,
                             allowTsInNodeModules: true,
                             compilerOptions: {
                                 sourceMap: isAnySourceMapEnabled,
@@ -256,6 +258,14 @@ module.exports = env => {
             }),
             // Does IPC communication with the {N} CLI to notify events when running in watch mode.
             new nsWebpack.WatchStateLoggerPlugin(),
+            // https://github.com/TypeStrong/ts-loader/blob/ea2fcf925ec158d0a536d1e766adfec6567f5fb4/README.md#faster-builds
+            // https://github.com/TypeStrong/ts-loader/blob/ea2fcf925ec158d0a536d1e766adfec6567f5fb4/README.md#hot-module-replacement
+            new ForkTsCheckerWebpackPlugin({
+                tsconfig: tsConfigPath,
+                async: false,
+                useTypescriptIncrementalApi: true,
+                memoryLimit: 4096
+            })
         ],
     };
 
@@ -295,12 +305,6 @@ module.exports = env => {
 
     if (hmr) {
         config.plugins.push(new webpack.HotModuleReplacementPlugin());
-
-        // With HMR ts-loader should run in `transpileOnly` mode,
-        // so assure type-checking with fork-ts-checker-webpack-plugin
-        config.plugins.push(new ForkTsCheckerWebpackPlugin({
-            tsconfig: tsConfigPath
-        }));
     }
 
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Take a look at the related issue.

## What is the new behavior?
The types check is always incremental and handled in a child process.

Related to: https://github.com/NativeScript/nativescript-dev-webpack/issues/925