### PR TITLE
fix(ios): emit inspector_modules as a module

### DIFF
--- a/demo/AngularApp/webpack.config.js
+++ b/demo/AngularApp/webpack.config.js
@@ -62,7 +62,7 @@ module.exports = env => {
     const entryPath = `.${sep}${entryModule}`;
     const entries = { bundle: entryPath, application: "./application.android" };
     if (platform === "ios") {
-        entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules.js";
+        entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules";
     };
 
     const ngCompilerTransformers = [];

--- a/demo/JavaScriptApp/webpack.config.js
+++ b/demo/JavaScriptApp/webpack.config.js
@@ -56,7 +56,7 @@ module.exports = env => {
     const entryPath = `.${sep}${entryModule}.js`;
     const entries = { bundle: entryPath, application: "./application.android" };
     if (platform === "ios") {
-        entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules.js";
+        entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules";
     };
 
     let sourceMapFilename = nsWebpack.getSourceMapFilename(hiddenSourceMap, __dirname, dist);

--- a/demo/TypeScriptApp/webpack.config.js
+++ b/demo/TypeScriptApp/webpack.config.js
@@ -60,7 +60,7 @@ module.exports = env => {
     const tsConfigPath = resolve(projectRoot, "tsconfig.tns.json");
 
     if (platform === "ios") {
-        entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules.js";
+        entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules";
     };
 
     let sourceMapFilename = nsWebpack.getSourceMapFilename(hiddenSourceMap, __dirname, dist);

--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -61,7 +61,7 @@ module.exports = env => {
     const entryPath = `.${sep}${entryModule}`;
     const entries = { bundle: entryPath };
     if (platform === "ios") {
-        entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules.js";
+        entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules";
     };
 
     const ngCompilerTransformers = [];

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -55,7 +55,7 @@ module.exports = env => {
     const entryPath = `.${sep}${entryModule}.js`;
     const entries = { bundle: entryPath };
     if (platform === "ios") {
-        entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules.js";
+        entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules";
     };
 
     let sourceMapFilename = nsWebpack.getSourceMapFilename(hiddenSourceMap, __dirname, dist);

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -59,7 +59,7 @@ module.exports = env => {
     const tsConfigPath = resolve(projectRoot, "tsconfig.tns.json");
 
     if (platform === "ios") {
-        entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules.js";
+        entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules";
     };
 
     let sourceMapFilename = nsWebpack.getSourceMapFilename(hiddenSourceMap, __dirname, dist);

--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -62,7 +62,7 @@ module.exports = env => {
     const entryPath = `.${sep}${entryModule}`;
     const entries = { bundle: entryPath };
     if (platform === "ios") {
-        entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules.js";
+        entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules";
     };
     console.log(`Bundling application for entryPath ${entryPath}...`);
 


### PR DESCRIPTION
This entry point does not resolve when transpiling `tns-core-modules`.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`inspector_modules.js` *file* is emitted as a separate entry point for iOS.

## What is the new behavior?
<!-- Describe the changes. -->

`inspector_modules` *module* is emitted as a separate entry point for iOS.

<!--
Fixes/Implements/Closes #[Issue Number].
-->

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla