### PR TITLE
fix: do not add inspector_modules entry when core modules are an external module

### DIFF
--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -60,7 +60,8 @@ module.exports = env => {
     const entryModule = `${nsWebpack.getEntryModule(appFullPath, platform)}.ts`;
     const entryPath = `.${sep}${entryModule}`;
     const entries = { bundle: entryPath };
-    if (platform === "ios") {
+    const areCoreModulesExternal = Array.isArray(env.externals) && env.externals.some(e => e.indexOf("tns-core-modules") > -1);
+    if (platform === "ios" && !areCoreModulesExternal) {
         entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules";
     };
 

--- a/templates/webpack.config.spec.ts
+++ b/templates/webpack.config.spec.ts
@@ -115,6 +115,20 @@ describe('webpack.config.js', () => {
                     expect(isCalled).toBe(true, 'Webpack.config.js must use the getConvertedExternals method');
                 });
 
+                if (platform === "ios") {
+                    it('has inspector_modules entry when tns-core-modules are not externals', () => {
+                        const input = getInput({ platform, externals: ['nativescript-vue'] });
+                        const config = webpackConfig(input);
+                        expect(config.entry["tns_modules/tns-core-modules/inspector_modules"]).toEqual("inspector_modules");
+                    });
+
+                    it('does not have inspector_modules entry when tns-core-modules are externals', () => {
+                        const input = getInput({ platform, externals: ['tns-core-modules'] });
+                        const config = webpackConfig(input);
+                        expect(config.entry["tns_modules/tns-core-modules/inspector_modules"]).toBeUndefined();
+                    });
+                }
+
                 [
                     {
                         input: ['nativescript-vue'],

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -54,7 +54,8 @@ module.exports = env => {
     const entryModule = nsWebpack.getEntryModule(appFullPath, platform);
     const entryPath = `.${sep}${entryModule}.js`;
     const entries = { bundle: entryPath };
-    if (platform === "ios") {
+    const areCoreModulesExternal = Array.isArray(env.externals) && env.externals.some(e => e.indexOf("tns-core-modules") > -1);
+    if (platform === "ios" && !areCoreModulesExternal) {
         entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules";
     };
 

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -58,7 +58,8 @@ module.exports = env => {
 
     const tsConfigPath = resolve(projectRoot, "tsconfig.tns.json");
 
-    if (platform === "ios") {
+    const areCoreModulesExternal = Array.isArray(env.externals) && env.externals.some(e => e.indexOf("tns-core-modules") > -1);
+    if (platform === "ios" && !areCoreModulesExternal) {
         entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules";
     };
 

--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -61,7 +61,8 @@ module.exports = env => {
     const entryModule = nsWebpack.getEntryModule(appFullPath, platform);
     const entryPath = `.${sep}${entryModule}`;
     const entries = { bundle: entryPath };
-    if (platform === "ios") {
+    const areCoreModulesExternal = Array.isArray(env.externals) && env.externals.some(e => e.indexOf("tns-core-modules") > -1);
+    if (platform === "ios" && !areCoreModulesExternal) {
         entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules";
     };
     console.log(`Bundling application for entryPath ${entryPath}...`);


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [x] Tests for the changes are included.

Related to: https://github.com/NativeScript/nativescript-cli/issues/4658