### PR TITLE
fix: follow the symlinks in JavaScript apps

### DIFF
--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -94,7 +94,7 @@ module.exports = env => {
                 '~': appFullPath
             },
             // don't resolve symlinks to symlinked modules
-            symlinks: false
+            symlinks: true
         },
         resolveLoader: {
             // don't resolve symlinks to symlinked loaders


### PR DESCRIPTION
We are already following the symlinks in TypeScript, Angular and Vue apps. It allows the plugin developers to link and develop their plugins directly in a JavaScript demo application

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

Related to: https://github.com/NativeScript/nativescript-dev-webpack/issues/656