### PR TITLE
fix: fix hmr for platform specific files in linked plugins

### DIFF
--- a/demo/JavaScriptApp/webpack.config.js
+++ b/demo/JavaScriptApp/webpack.config.js
@@ -5,7 +5,6 @@ const nsWebpack = require("nativescript-dev-webpack");
 const nativescriptTarget = require("nativescript-dev-webpack/nativescript-target");
 const CleanWebpackPlugin = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
-const ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 const { NativeScriptWorkerPlugin } = require("nativescript-worker-loader/NativeScriptWorkerPlugin");
 const TerserPlugin = require("terser-webpack-plugin");
@@ -236,9 +235,6 @@ module.exports = env => {
             }),
             // Does IPC communication with the {N} CLI to notify events when running in watch mode.
             new nsWebpack.WatchStateLoggerPlugin(),
-            new ExtraWatchWebpackPlugin({
-                files: [`node_modules/**/*.${platform}.js`]
-            })
         ],
     };
 

--- a/demo/TypeScriptApp/webpack.config.js
+++ b/demo/TypeScriptApp/webpack.config.js
@@ -6,7 +6,6 @@ const nativescriptTarget = require("nativescript-dev-webpack/nativescript-target
 const CleanWebpackPlugin = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
-const ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 const { NativeScriptWorkerPlugin } = require("nativescript-worker-loader/NativeScriptWorkerPlugin");
 const TerserPlugin = require("terser-webpack-plugin");
@@ -267,9 +266,6 @@ module.exports = env => {
                 useTypescriptIncrementalApi: true,
                 memoryLimit: 4096
             }),
-            new ExtraWatchWebpackPlugin({
-                files: [`node_modules/**/*.${platform}.ts`]
-            })
         ],
     };
 

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -5,7 +5,6 @@ const nsWebpack = require("nativescript-dev-webpack");
 const nativescriptTarget = require("nativescript-dev-webpack/nativescript-target");
 const CleanWebpackPlugin = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
-const ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 const { NativeScriptWorkerPlugin } = require("nativescript-worker-loader/NativeScriptWorkerPlugin");
 const TerserPlugin = require("terser-webpack-plugin");
@@ -234,10 +233,7 @@ module.exports = env => {
                 platforms,
             }),
             // Does IPC communication with the {N} CLI to notify events when running in watch mode.
-            new nsWebpack.WatchStateLoggerPlugin(),
-            new ExtraWatchWebpackPlugin({
-                files: [`node_modules/**/*.${platform}.js`]
-            })
+            new nsWebpack.WatchStateLoggerPlugin()
         ],
     };
 

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -6,7 +6,6 @@ const nativescriptTarget = require("nativescript-dev-webpack/nativescript-target
 const CleanWebpackPlugin = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
-const ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 const { NativeScriptWorkerPlugin } = require("nativescript-worker-loader/NativeScriptWorkerPlugin");
 const TerserPlugin = require("terser-webpack-plugin");
@@ -265,9 +264,6 @@ module.exports = env => {
                 async: false,
                 useTypescriptIncrementalApi: true,
                 memoryLimit: 4096
-            }),
-            new ExtraWatchWebpackPlugin({
-                files: [`node_modules/**/*.${platform}.ts`]
             })
         ],
     };

--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -3,7 +3,6 @@ const { join, relative, resolve, sep } = require("path");
 const webpack = require("webpack");
 const CleanWebpackPlugin = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
-const ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 const TerserPlugin = require("terser-webpack-plugin");
 
@@ -258,10 +257,7 @@ module.exports = env => {
                 platforms,
             }),
             // Does IPC communication with the {N} CLI to notify events when running in watch mode.
-            new nsWebpack.WatchStateLoggerPlugin(),
-            new ExtraWatchWebpackPlugin({
-                files: [`node_modules/**/*.${platform}.ts`, `node_modules/**/*.${platform}.js`]
-            })
+            new nsWebpack.WatchStateLoggerPlugin()
         ],
     };
 


### PR DESCRIPTION
Currently `hmr` for platform specific files in linked plugins work only in intervals of 60 seconds. This is due to the fact that `CachedInputFileSystem` of `webpack` has a cache that is invalidated on every 60seconds. We used `ExtaWatchPlugin` in order to add platform specific files to the webpack's compilation. This plugin doesn't follow symlinks and this led to the different problems when applying changes from platform specific files. So we decided to remove it and to override correctly watch's file system from webpack. We have a logic for overriding webpack's watchFileSystem but this logic doesn't work as it seems it is not compatible with webpack v4.0.

Currently `compiler.watchFileSystem.watch` has 2 callbacks - `callback` and `callbackUndelayed`. The `callbackUndelayed` is executed on every file's change as we can see [here](https://github.com/webpack/webpack/blob/af4cb35784be468c32da5b79c33b88e83cad1257/lib/node/NodeWatchFileSystem.js#L45). We override this callback and purge the file's cache on `callbackUndelayed`. This way we ensure the cache is invalided for the changed file and `hmr` after that will work.

Rel to: https://github.com/NativeScript/nativescript-dev-webpack/issues/942

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
`hmr` doesn't work for platform specific files in linked plugins. 

## What is the new behavior?
`hmr` works for platform specific files in linked plugins.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla