### PR TITLE
fix: do not show warning for format differences in templates

### DIFF
--- a/projectFilesManager.js
+++ b/projectFilesManager.js
@@ -5,7 +5,7 @@ const { isTypeScript, isAngular, isVue } = require("./projectHelpers");
 
 function addProjectFiles(projectDir) {
     const projectTemplates = getProjectTemplates(projectDir);
-    Object.keys(projectTemplates).forEach(function(templateName) {
+    Object.keys(projectTemplates).forEach(function (templateName) {
         const templateDestination = projectTemplates[templateName];
         templateName = path.resolve(templateName);
         copyTemplate(templateName, templateDestination);
@@ -14,7 +14,7 @@ function addProjectFiles(projectDir) {
 
 function removeProjectFiles(projectDir) {
     const projectTemplates = getProjectTemplates(projectDir);
-    Object.keys(projectTemplates).forEach(function(templateName) {
+    Object.keys(projectTemplates).forEach(function (templateName) {
         const templateDestination = projectTemplates[templateName];
         deleteFile(templateDestination);
     });
@@ -32,7 +32,7 @@ function compareProjectFiles(projectDir) {
         if (fs.existsSync(currentTemplatePath)) {
             const currentTemplate = fs.readFileSync(currentTemplatePath).toString();
             const newTemplate = fs.readFileSync(newTemplatePath).toString();
-            if (newTemplate !== currentTemplate) {
+            if (newTemplate.replace(/\s/g, '') !== currentTemplate.replace(/\s/g, '')) {
                 const message = `The current project contains a ${path.basename(currentTemplatePath)} file located at ${currentTemplatePath} that differs from the one in the new version of the nativescript-dev-webpack plugin located at ${newTemplatePath}. Some of the plugin features may not work as expected until you manually update the ${path.basename(currentTemplatePath)} file or automatically update it using "./node_modules/.bin/update-ns-webpack --configs" command.`;
                 console.info(`\x1B[33;1m${message}\x1B[0m`);
             }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
When you add a new line at the end of your `webpack.config` or `tsconfig.tns.json`, the postinstall will show a warning that your configs are outdated.

## What is the new behavior?
The whitespace changes are ignored during the comparison.
[CLA]: http://www.nativescript.org/cla