### PR TITLE
fix: don't throw an error from after-prepare hook when running legacy workflow with CLI <= v5.4.2 and nativescript-dev-webpack@next

### DIFF
--- a/lib/after-prepare.js
+++ b/lib/after-prepare.js
@@ -2,6 +2,10 @@ const { installSnapshotArtefacts } = require("../snapshot/android/project-snapsh
 const { shouldSnapshot } = require("./utils");
 
 module.exports = function (hookArgs) {
+	if (hookArgs && hookArgs.appFilesUpdaterOptions && !hookArgs.appFilesUpdaterOptions.bundle) {
+		return;
+	}
+
 	const env = hookArgs.prepareData.env || {};
 	const shouldSnapshotOptions = {
 		platform: hookArgs.prepareData.platform,


### PR DESCRIPTION
Rel to: https://github.com/NativeScript/nativescript-dev-webpack/issues/945

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla