### PR TITLE
fix: inject app.css file from unit-test-runner on test command

### DIFF
--- a/unit-testing-config-loader.js
+++ b/unit-testing-config-loader.js
@@ -6,10 +6,13 @@ module.exports = function ({ appFullPath, projectRoot, angular, rootPagesRegExp 
     const testFilesRegExp = /tests\/.*\.(ts|js)/;
     const runnerFullPath = join(projectRoot, "node_modules", "nativescript-unit-test-runner");
     const runnerRelativePath = convertSlashesInPath(relative(appFullPath, runnerFullPath));
+    const appCssFilePath = join(runnerRelativePath, "app.css");
     let source = `
         require("tns-core-modules/bundle-entry-points");
         const runnerContext = require.context("${runnerRelativePath}", true, ${rootPagesRegExp});
         global.registerWebpackModules(runnerContext);
+        global.registerModule("${appCssFilePath}", () => require("${appCssFilePath}"));
+        require("tns-core-modules/application").setCssFileName("${appCssFilePath}");
     `;
 
     if (angular) {


### PR DESCRIPTION
Currently the app.css file from unit-test-runner is not included in bundle/vendor files on test command so the application remains without app.css file.  The `tns-core-modules` shows an error in this situation in their latest next versions:
```
JS: Error: Could not load CSS from ./app.css: Error: com.tns.NativeScriptException: Failed to find module: "./app.css", relative to: app//
JS:     com.tns.Module.resolvePathHelper(Module.java:146)
JS:     com.tns.Module.resolvePath(Module.java:55)
JS:     com.tns.Runtime.callJSMethodNative(Native Method)
JS:     com.tns.Runtime.dispatchCallJSMethodNative(Runtime.java:1212)
JS:     com.tns.Runtime.callJSMethodImpl(Runtime.java:1092)
JS:     com.tns.Runtime.callJSMethod(Runtime.java:1079)
JS:     com.tns.Runtime.callJSMethod(Runtime.java:1059)
JS:     com.tns.Runtime.callJSMethod(Runtime.java:1051)
JS:     com.tns.NativeScriptActivity.onCreate(NativeScriptActivity.java:19)
JS:     android.app.Activity.performCreate(Activity.java:7136)
JS:     android.app.Activity.performCreate(Activity.java:7127)
JS:     android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1271)
JS:     android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2893)
JS:     android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3048)
JS:     android.app.servertransac...
```

So we need to inject app.css in order to prevent this error :)

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla