### PR TITLE
fix: hmr should work with uglify

### DIFF
--- a/plugins/WatchStateLoggerPlugin.ts
+++ b/plugins/WatchStateLoggerPlugin.ts
@@ -64,10 +64,9 @@ function getWebpackRuntimeOnlyFiles(compilation) {
 function getEntryPointFiles(compilation) {
     const entryPointFiles = [];
     try {
-       Array.from(compilation.entrypoints.values())
+        Array.from(compilation.entrypoints.values())
             .forEach((entrypoint: any) => {
-                const entryChunk = entrypoint.chunks.find(chunk => chunk.name === entrypoint.options.name);
-                if (entryChunk) {
+                for (const entryChunk of entrypoint.chunks) {
                     entryChunk.files.forEach(fileName => {
                         if (fileName.indexOf("hot-update") === -1) {
                             entryPointFiles.push(fileName);
@@ -79,5 +78,6 @@ function getEntryPointFiles(compilation) {
         console.log("Warning: Unable to find Webpack entry point files.");
     }
 
-    return entryPointFiles;
+    return entryPointFiles
+        .filter((value, index, self) => self.indexOf(value) === index); // get only the unique files
 }


### PR DESCRIPTION
Currently `hmr` with `--env.uglify` is not working as the uglifier touches all files. This leads to emit of files that are not hot updates. When CLI finds such files, it decides hmr is not successful and restarts the application.
However, some of the emitted files are not actully changed. These emitted (and not changed) files are chunks of the entry points - as we are with HMR if there's an actual change for them, we'll receive hot-update files.
Currently there's a logic to skip all emitted entry points and webpack runtime files (`runtime.js`) when we are with HMR. To fix the current issue, extend this logic to skip emitted chunks of entry points as well  when we are with HMR and there's no hot-update for them.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla