### PR TITLE
fix: the Lazy transformer is not crashing the TypeScript program anymore

### DIFF
--- a/demo/TypeScriptApp/package.json
+++ b/demo/TypeScriptApp/package.json
@@ -28,7 +28,7 @@
     "mochawesome": "~3.1.2",
     "nativescript-dev-appium": "next",
     "nativescript-dev-webpack": "next",
-    "typescript": "~3.2.2",
+    "typescript": "~3.4.1",
     "node-sass": "^4.12.0"
   },
   "scripts": {

--- a/transformers/ns-replace-lazy-loader.spec.ts
+++ b/transformers/ns-replace-lazy-loader.spec.ts
@@ -44,6 +44,43 @@ describe("@ngtools/webpack transformers", () => {
                     export { AppModule };`
             },
             {
+                name: "should add providers and NgModuleFactoryLoader when providers is missing and decomposition is used",
+                rawAppModule: `
+                    import { NgModule } from "@angular/core";
+                    import { NativeScriptModule } from "nativescript-angular/nativescript.module";
+                    import { AppComponent } from "./app.component";
+
+                    const declarationsArray = [AppComponent];
+                    @NgModule({
+                        bootstrap: [
+                            AppComponent
+                        ],
+                        imports: [
+                            NativeScriptModule
+                        ],
+                        declarations: [
+                            ...declarationsArray
+                        ]
+                    })
+                    export class AppModule { }
+              `,
+                transformedAppModule: `
+                    import * as tslib_1 from "tslib"; import { NgModule } from "@angular/core";
+                    import { NativeScriptModule } from "nativescript-angular/nativescript.module";
+                    import { AppComponent } from "./app.component";
+                    ${NgLazyLoaderCode}
+                    const declarationsArray = [AppComponent];
+                    let AppModule = class AppModule { };
+                    AppModule = tslib_1.__decorate([ NgModule({
+                        bootstrap: [ AppComponent ],
+                        imports: [ NativeScriptModule ],
+                        declarations: [ ...declarationsArray ],
+                        providers: [{ provide: nsNgCoreImport_Generated.NgModuleFactoryLoader, useClass: NSLazyModulesLoader_Generated }] })
+                    ],
+                    AppModule);
+                    export { AppModule };`
+            },
+            {
                 name: "should add NgModuleFactoryLoader when the providers array is empty",
                 rawAppModule: `
                     import { NgModule } from "@angular/core";

--- a/transformers/ns-replace-lazy-loader.ts
+++ b/transformers/ns-replace-lazy-loader.ts
@@ -93,7 +93,8 @@ export function addArrayPropertyValueToNgModule(
 
             // the target field is missing, we will insert it @NgModule({ otherProps })
             const lastConfigObjPropertyNode = ngModuleConfigObjectNode.properties[ngModuleConfigObjectNode.properties.length - 1];
-            const newTargetPropertyNode = ts.createIdentifier(`${targetPropertyName}: [${newPropertyValue}]`);
+
+            const newTargetPropertyNode = ts.createPropertyAssignment(targetPropertyName, ts.createIdentifier(`[${newPropertyValue}]`));
 
             return [
                 new AddNodeOperation(sourceFile, lastConfigObjPropertyNode, undefined, newTargetPropertyNode),


### PR DESCRIPTION
Create PropertyAssignment instead of string literal (Identifier) when modifying the NgModule.

It seems that in some cases (e.g. when there is decomposition in another NgModule property), the TypeScipt program is trying to read `node.name.kind` for each property causing an exception for Identifiers)

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [x] Tests for the changes are included.

Related to: https://github.com/NativeScript/nativescript-dev-webpack/issues/960