### PR TITLE
feat(hooks): improve hooks handling

### DIFF
--- a/lib/before-checkForChanges.js
+++ b/lib/before-checkForChanges.js
@@ -1,0 +1,16 @@
+module.exports = function ($staticConfig, hookArgs) {
+    const majorVersionMatch = ($staticConfig.version || '').match(/^(\d+)\./);
+    const majorVersion = majorVersionMatch && majorVersionMatch[1] && +majorVersionMatch[1];
+    if (majorVersion && majorVersion < 6) {
+        // check if we are using the bundle workflow or the legacy one.
+        const isUsingBundleWorkflow = hookArgs &&
+            hookArgs.checkForChangesOpts &&
+            hookArgs.checkForChangesOpts.projectChangesOptions &&
+            hookArgs.checkForChangesOpts.projectChangesOptions.bundle;
+
+        if (isUsingBundleWorkflow) {
+            const packageJsonData = require("../package.json")
+            throw new Error(`The current version of ${packageJsonData.name} (${packageJsonData.version}) is not compatible with the used CLI: ${$staticConfig.version}. Please upgrade your NativeScript CLI version (npm i -g nativescript).`);
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "scripts": {
     "postinstall": "node postinstall.js",
+    "preuninstall": "node preuninstall.js",
     "postpack": "rm -rf node_modules",
     "prepare": "tsc && npm run jasmine",
     "test": "npm run prepare && npm run jasmine",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
         "type": "after-prepare",
         "script": "lib/after-prepare.js",
         "inject": true
+      },
+      {
+        "type": "before-checkForChanges",
+        "script": "lib/before-checkForChanges.js",
+        "inject": true
       }
     ]
   },

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const { dirname } = require("path");
 const hook = require("nativescript-hook")(__dirname);
 
 const { compareProjectFiles } = require("./projectFilesManager");

--- a/postinstall.js
+++ b/postinstall.js
@@ -4,12 +4,47 @@ const hook = require("nativescript-hook")(__dirname);
 
 const { compareProjectFiles } = require("./projectFilesManager");
 const { getProjectDir } = require("./projectHelpers");
+const path = require("path");
+const fs = require("fs");
 
 const projectDir = getProjectDir();
 
+// This method is introduced as in version 1.0.0 of nativescript-dev-webpack (compatible and required for NativeScript 6.0.0)
+// we have changed a lot of hooks and old ones are incompatible. This should be automatically handled with preuninstall script of the old version.
+// However, old versions of nativescript-dev-webpack do not have such logic, so remove them manually on postinstall of the current version.
+// This logic can be removed later, once most of the projects are migrated to 1.0.0 of the package or later.
+// These new versions have preuninstall script that will automatically handle this case.
+function removeOldHooks() {
+    const oldHooks = [
+        "before-prepareJSApp",
+        "before-cleanApp",
+        "before-watch",
+        "after-watch",
+        "before-watchPatterns",
+        "before-shouldPrepare",
+        "after-prepare",
+        "before-preview-sync"
+    ];
+
+    const hooksDir = path.join(projectDir, "hooks");
+    const pkgName = require("./package.json").name;
+    const filename = `${pkgName}.js`;
+    oldHooks.forEach(hookName => {
+        const hookPath = path.join(hooksDir, hookName, filename);
+
+        try {
+            if (fs.existsSync(hookPath)) {
+                fs.unlinkSync(hookPath);
+            }
+        } catch (err) {
+            console.warn(`${pkgName} postinstall task: unable to delete hook ${hookPath}. Error is: ${err}`);
+        }
+    });
+}
+
 if (projectDir) {
     compareProjectFiles(projectDir);
-
+    removeOldHooks();
     hook.postinstall();
     const installer = require("./installer");
     installer.install();
@@ -17,3 +52,4 @@ if (projectDir) {
     // We are installing dev dependencies for the nativescript-dev-webpack plugin.
     console.log("Skipping postinstall artifacts! We assumed the nativescript-dev-webpack is installing devDependencies");
 }
+

--- a/preuninstall.js
+++ b/preuninstall.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const hook = require("nativescript-hook")(__dirname);
+
+const { getProjectDir } = require("./projectHelpers");
+
+const projectDir = getProjectDir();
+
+if (projectDir) {
+    hook.preuninstall();
+}


### PR DESCRIPTION
#### fix(preuninstall): add preuninstall script to remove old hooks
During migration from one version to another or when the plugin is removed from application we need to remove its hooks. This is usually done in preuninstall script, however, it was missing until now. This causes several issues when the version is updated as old hooks remain, but they may not be valid anymore.

#### fix(postinstall): remove old hooks
As in 1.0.0 and CLI 6.0 we've changed the way nativescript-dev-webpack interacts with CLI, we need to remove hooks from previous nativescript-dev-webpack versions and use new ones. Usually this should happen with preuninstall script of the old version that removes the hooks. However, our current live version does not have such logic, so implement this in the postinstall of the current version.
This way we try to ensure the current plugin will work correctly.


#### 
feat(hooks): add before-checkForChanges hook
Add before-checkForChanges hook to prevent users from using the current version of the plugin with CLI 5.x.x or older. These two versions are incompatible, so add an error in case older CLI is used.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
`nativescript-dev-webpack` hooks cause issues in different scenarios - the package does not remove its own hooks on preuninstall, so upgrading it causes issues as old hooks remain in the project.
Also in case the new version of the plugin is used with old CLI, it fails with error `Cannot read property env of undefined` which does not give useful information to the user.

## What is the new behavior?
* During uninstall, the plugin removes its old hooks.
* At postinstall we ensure old hooks are removed before installing the new ones.
* A new hook is added - `before-checkForChanges` that prevents users who have old CLI and the new version of the plugin (with bundle workflow) - we know this combination will not work, so throw a descriptive error message in this case.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla