### PR TITLE
refactor: HMR and webpack improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ jasmine-config/reporter.d.ts
 jasmine-config/reporter.js
 jasmine-config/reporter.js.map
 
+bundle-config-loader.d.ts
+bundle-config-loader.js
+bundle-config-loader.js.map
+
 **/*.spec.js*
 **/*.spec.d.ts*
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,38 +2,34 @@
 node_modules
 *.tgz
 package-lock.json
+*.js.map
 
 plugins/NativeScriptAngularCompilerPlugin.d.ts
 plugins/NativeScriptAngularCompilerPlugin.js
-plugins/NativeScriptAngularCompilerPlugin.js.map
 
 transformers/*.d.ts
 transformers/*.js
-transformers/*.js.map
 
 utils/*.d.ts
 utils/*.js
-utils/*.js.map
+
+hmr/*.d.ts
+hmr/*.js
 
 plugins/PlatformFSPlugin.d.ts
 plugins/PlatformFSPlugin.js
-plugins/PlatformFSPlugin.js.map
 
 plugins/WatchStateLoggerPlugin.d.ts
 plugins/WatchStateLoggerPlugin.js
-plugins/WatchStateLoggerPlugin.js.map
 
 host/resolver.d.ts
 host/resolver.js
-host/resolver.js.map
 
 jasmine-config/reporter.d.ts
 jasmine-config/reporter.js
-jasmine-config/reporter.js.map
 
 bundle-config-loader.d.ts
 bundle-config-loader.js
-bundle-config-loader.js.map
 
 **/*.spec.js*
 **/*.spec.d.ts*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,16 @@
             "args": [ "--env.android", "--env.aot" ],
             "runtimeArgs": [ "--preserve-symlinks" ],
             "stopOnEntry": true,
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "TypeScriptApp Webpack",
+            "cwd": "${workspaceFolder}/demo/TypeScriptApp",
+            "program": "${workspaceFolder}/demo/TypeScriptApp/node_modules/.bin/webpack",
+            "args": [ "--env.android" ],
+            "stopOnEntry": true,
+            "preLaunchTask": "npm:tsc"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558 
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label":"npm:tsc",
+            "type": "npm",
+            "script": "tsc",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/bundle-config-loader.js
+++ b/bundle-config-loader.js
@@ -2,7 +2,14 @@ const unitTestingConfigLoader = require("./unit-testing-config-loader");
 
 module.exports = function (source, map) {
     this.cacheable();
-    const { angular = false, loadCss = true, unitTesting, projectRoot, appFullPath, registerModules = /(root|page)\.(xml|css|js|ts|scss)$/ } = this.query;
+    const {
+        angular = false,
+        loadCss = true,
+        unitTesting,
+        projectRoot,
+        appFullPath,
+        registerModules = /(root|page)(\.(land|port|phone|tablet|minH\d+|minW\d+|minWH\d+))?\.(xml|css|js|ts|scss)$/ 
+    } = this.query;
 
     if (unitTesting) {
         source = unitTestingConfigLoader({ appFullPath, projectRoot, angular, rootPagesRegExp: registerModules });

--- a/bundle-config-loader.ts
+++ b/bundle-config-loader.ts
@@ -2,6 +2,9 @@ import unitTestingConfigLoader from "./unit-testing-config-loader";
 import { loader } from "webpack";
 import { getOptions } from "loader-utils";
 
+// Matches all source, markup and style files that are not in App_Resources
+const defaultMatch = /(?<!App_Resources.*)\.(xml|css|js|ts|scss)$/;
+
 const loader: loader.Loader = function (source, map) {
     const {
         angular = false,
@@ -9,8 +12,8 @@ const loader: loader.Loader = function (source, map) {
         unitTesting,
         projectRoot,
         appFullPath,
-        registerModules = /(root|page)(\.(land|port|phone|tablet|minH\d+|minW\d+|minWH\d+))?\.(xml|css|js|ts|scss)$/
-    } = getOptions(this);;
+        registerModules = defaultMatch,
+    } = getOptions(this);
 
     if (unitTesting) {
         source = unitTestingConfigLoader({ appFullPath, projectRoot, angular, rootPagesRegExp: registerModules });

--- a/bundle-config-loader.ts
+++ b/bundle-config-loader.ts
@@ -1,15 +1,16 @@
-const unitTestingConfigLoader = require("./unit-testing-config-loader");
+import unitTestingConfigLoader from "./unit-testing-config-loader";
+import { loader } from "webpack";
+import { getOptions } from "loader-utils";
 
-module.exports = function (source, map) {
-    this.cacheable();
+const loader: loader.Loader = function (source, map) {
     const {
         angular = false,
         loadCss = true,
         unitTesting,
         projectRoot,
         appFullPath,
-        registerModules = /(root|page)(\.(land|port|phone|tablet|minH\d+|minW\d+|minWH\d+))?\.(xml|css|js|ts|scss)$/ 
-    } = this.query;
+        registerModules = /(root|page)(\.(land|port|phone|tablet|minH\d+|minW\d+|minWH\d+))?\.(xml|css|js|ts|scss)$/
+    } = getOptions(this);;
 
     if (unitTesting) {
         source = unitTestingConfigLoader({ appFullPath, projectRoot, angular, rootPagesRegExp: registerModules });
@@ -75,3 +76,6 @@ module.exports = function (source, map) {
 
     this.callback(null, source, map);
 };
+
+
+export default loader;

--- a/bundle-config-loader.ts
+++ b/bundle-config-loader.ts
@@ -3,7 +3,7 @@ import { loader } from "webpack";
 import { getOptions } from "loader-utils";
 
 // Matches all source, markup and style files that are not in App_Resources
-const defaultMatch = /(?<!App_Resources.*)\.(xml|css|js|ts|scss)$/;
+const defaultMatch = /(?<!App_Resources.*)\.(xml|css|js|(?<!d\.)ts|scss)$/;
 
 const loader: loader.Loader = function (source, map) {
     const {

--- a/demo/AngularApp/webpack.config.js
+++ b/demo/AngularApp/webpack.config.js
@@ -33,7 +33,6 @@ module.exports = env => {
 
     // Default destination inside platforms/<platform>/...
     const dist = resolve(projectRoot, nsWebpack.getAppPath(platform, projectRoot));
-    const appResourcesPlatformDir = platform === "android" ? "Android" : "iOS";
 
     const {
         // The 'appPath' and 'appResourcesPath' values are fetched from

--- a/demo/JavaScriptApp/webpack.config.js
+++ b/demo/JavaScriptApp/webpack.config.js
@@ -173,6 +173,7 @@ module.exports = env => {
                                 unitTesting,
                                 appFullPath,
                                 projectRoot,
+                                registerModules: /(?<!App_Resources.*)(?<!\.\/application)(?<!\.\/activity)\.(xml|css|js|(?<!d\.)ts|scss)$/
                             }
                         },
                     ].filter(loader => !!loader)

--- a/demo/JavaScriptApp/webpack.config.js
+++ b/demo/JavaScriptApp/webpack.config.js
@@ -28,7 +28,6 @@ module.exports = env => {
 
     // Default destination inside platforms/<platform>/...
     const dist = resolve(projectRoot, nsWebpack.getAppPath(platform, projectRoot));
-    const appResourcesPlatformDir = platform === "android" ? "Android" : "iOS";
 
     const {
         // The 'appPath' and 'appResourcesPath' values are fetched from
@@ -103,7 +102,7 @@ module.exports = env => {
                 '~': appFullPath
             },
             // don't resolve symlinks to symlinked modules
-            symlinks: false
+            symlinks: true
         },
         resolveLoader: {
             // don't resolve symlinks to symlinked loaders
@@ -180,18 +179,8 @@ module.exports = env => {
                 },
 
                 {
-                    test: /-page(\.(land|port|phone|tablet|minH\d+|minW\d+|minWH\d+))?\.js$/,
-                    use: "nativescript-dev-webpack/script-hot-loader"
-                },
-
-                {
-                    test: /\.(css|scss)$/,
-                    use: "nativescript-dev-webpack/style-hot-loader"
-                },
-
-                {
-                    test: /\.(html|xml)$/,
-                    use: "nativescript-dev-webpack/markup-hot-loader"
+                    test: /\.(js|css|scss|html|xml)$/,
+                    use: "nativescript-dev-webpack/hmr/hot-loader"
                 },
 
                 { test: /\.(html|xml)$/, use: "nativescript-dev-webpack/xml-namespace-loader" },
@@ -234,7 +223,7 @@ module.exports = env => {
                 platforms,
             }),
             // Does IPC communication with the {N} CLI to notify events when running in watch mode.
-            new nsWebpack.WatchStateLoggerPlugin(),
+            new nsWebpack.WatchStateLoggerPlugin()
         ],
     };
 

--- a/demo/JavaScriptApp/webpack.config.js
+++ b/demo/JavaScriptApp/webpack.config.js
@@ -180,7 +180,7 @@ module.exports = env => {
                 },
 
                 {
-                    test: /-page\.js$/,
+                    test: /-page(\.(land|port|phone|tablet|minH\d+|minW\d+|minWH\d+))?\.js$/,
                     use: "nativescript-dev-webpack/script-hot-loader"
                 },
 

--- a/demo/TypeScriptApp/webpack.config.js
+++ b/demo/TypeScriptApp/webpack.config.js
@@ -186,7 +186,7 @@ module.exports = env => {
                 },
 
                 {
-                    test: /-page\.ts$/,
+                    test: /-page(\.(land|port|phone|tablet|minH\d+|minW\d+|minWH\d+))?\.ts$/,
                     use: "nativescript-dev-webpack/script-hot-loader"
                 },
 

--- a/demo/TypeScriptApp/webpack.config.js
+++ b/demo/TypeScriptApp/webpack.config.js
@@ -29,7 +29,6 @@ module.exports = env => {
 
     // Default destination inside platforms/<platform>/...
     const dist = resolve(projectRoot, nsWebpack.getAppPath(platform, projectRoot));
-    const appResourcesPlatformDir = platform === "android" ? "Android" : "iOS";
 
     const {
         // The 'appPath' and 'appResourcesPath' values are fetched from
@@ -186,18 +185,8 @@ module.exports = env => {
                 },
 
                 {
-                    test: /-page(\.(land|port|phone|tablet|minH\d+|minW\d+|minWH\d+))?\.ts$/,
-                    use: "nativescript-dev-webpack/script-hot-loader"
-                },
-
-                {
-                    test: /\.(css|scss)$/,
-                    use: "nativescript-dev-webpack/style-hot-loader"
-                },
-
-                {
-                    test: /\.(html|xml)$/,
-                    use: "nativescript-dev-webpack/markup-hot-loader"
+                    test: /\.(ts|css|scss|html|xml)$/,
+                    use: "nativescript-dev-webpack/hmr/hot-loader"
                 },
 
                 { test: /\.(html|xml)$/, use: "nativescript-dev-webpack/xml-namespace-loader" },
@@ -265,7 +254,7 @@ module.exports = env => {
                 async: false,
                 useTypescriptIncrementalApi: true,
                 memoryLimit: 4096
-            }),
+            })
         ],
     };
 

--- a/demo/TypeScriptApp/webpack.config.js
+++ b/demo/TypeScriptApp/webpack.config.js
@@ -179,6 +179,7 @@ module.exports = env => {
                                 unitTesting,
                                 appFullPath,
                                 projectRoot,
+                                registerModules: /(?<!App_Resources.*)(?<!\.\/application)(?<!\.\/activity)\.(xml|css|js|(?<!d\.)ts|scss)$/
                             }
                         },
                     ].filter(loader => !!loader)

--- a/hmr/hmr-update.js
+++ b/hmr/hmr-update.js
@@ -1,7 +1,0 @@
-module.exports = () => {
-    const update = require("../hot");
-    const fileSystemModule = require("tns-core-modules/file-system");
-    const applicationFiles = fileSystemModule.knownFolders.currentApp();
-    const latestHash = __webpack_require__["h"]();
-    return update(latestHash, filename => applicationFiles.getFile(filename));
-}

--- a/hmr/hmr-update.ts
+++ b/hmr/hmr-update.ts
@@ -1,0 +1,11 @@
+
+import update from "../hot";
+import { knownFolders } from "tns-core-modules/file-system";
+
+declare const __webpack_require__: any;
+
+export function hmrUpdate() {
+    const applicationFiles = knownFolders.currentApp();
+    const latestHash = __webpack_require__["h"]();
+    return update(latestHash, filename => applicationFiles.getFile(filename));
+}

--- a/hmr/hmr-update.ts
+++ b/hmr/hmr-update.ts
@@ -1,4 +1,3 @@
-
 import update from "../hot";
 import { knownFolders } from "tns-core-modules/file-system";
 

--- a/hmr/hot-loader.ts
+++ b/hmr/hot-loader.ts
@@ -1,0 +1,36 @@
+import { loader } from "webpack";
+import { convertToUnixPath } from "../lib/utils";
+import { extname } from "path";
+
+const extMap = {
+    ".css" : "style",
+    ".scss" : "style",
+    ".less" : "style",
+    ".js" : "script",
+    ".ts" : "script",
+    ".xml" : "markup",
+    ".html" : "markup",
+}
+
+const loader: loader.Loader = function (source, map) {
+    const moduleRelativePath = this.resourcePath.replace(this.rootContext, ".");
+    const modulePath = convertToUnixPath(moduleRelativePath);
+    const ext = extname(modulePath).toLowerCase();
+    const typeStyle = extMap[ext] || "unknown";
+
+    const hotCode = `
+if (module.hot && global._shouldAutoAcceptModule && global._shouldAutoAcceptModule(module.id)) {
+    console.log("AUTO ACCEPT MODULE: ", module.id, '${modulePath}')
+    module.hot.accept();
+    module.hot.dispose(() => {
+        global.hmrRefresh({ type: '${typeStyle}', path: '${modulePath}' });
+    })
+}`;
+
+    this.callback(null, `${source};${hotCode}`, map);
+};
+
+export default loader;
+
+
+

--- a/hmr/hot-loader.ts
+++ b/hmr/hot-loader.ts
@@ -17,7 +17,7 @@ const loader: loader.Loader = function (source, map) {
     const moduleRelativePath = this.resourcePath.replace(this.rootContext, ".");
     const modulePath = convertToUnixPath(moduleRelativePath);
     const ext = extname(modulePath).toLowerCase();
-    const typeStyle = extMap[ext] || "unknown";
+    const moduleType = extMap[ext] || "unknown";
 
     const options = getOptions(this) || {};
     const alwaysSelfAccept = options.alwaysSelfAccept;
@@ -31,7 +31,7 @@ if (module.hot ${alwaysSelfAccept ? "" : shouldAutoAcceptCheck} ) {
     ${trace ? traceCode : ""}
     module.hot.accept();
     module.hot.dispose(() => {
-        global.hmrRefresh({ type: "${typeStyle}", path: "${modulePath}" });
+        global.hmrRefresh({ type: "${moduleType}", path: "${modulePath}" });
     });
 }`;
 

--- a/hmr/index.js
+++ b/hmr/index.js
@@ -1,1 +1,0 @@
-module.exports.hmrUpdate = require("./hmr-update");

--- a/hmr/index.ts
+++ b/hmr/index.ts
@@ -1,0 +1,1 @@
+export { hmrUpdate } from "./hmr-update";

--- a/jasmine-config/jasmine.json
+++ b/jasmine-config/jasmine.json
@@ -1,7 +1,8 @@
 {
   "spec_dir": ".",
   "spec_files": [
-	"./!(node_modules)/**/*.spec.js",
+	"!node_modules/**/*.spec.js",
+	"!demo/**/*.spec.js",
 	"./*.spec.js"
   ],
   "helpers": [

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "jasmine-spec-reporter": "^4.2.1",
     "loader-utils": "^1.2.3",
     "proxyquire": "2.1.0",
+    "tns-core-modules": "next",
     "typescript": "~3.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -77,12 +77,15 @@
     "@angular/compiler-cli": "8.0.0",
     "@ngtools/webpack": "8.0.0",
     "@types/jasmine": "^3.3.7",
+    "@types/loader-utils": "^1.1.3",
     "@types/node": "^10.12.12",
     "@types/proxyquire": "1.3.28",
     "@types/semver": "^6.0.0",
+    "@types/webpack": "^4.4.34",
     "conventional-changelog-cli": "^1.3.22",
     "jasmine": "^3.2.0",
     "jasmine-spec-reporter": "^4.2.1",
+    "loader-utils": "^1.2.3",
     "proxyquire": "2.1.0",
     "typescript": "~3.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
     "url": "https://github.com/NativeScript/nativescript-dev-webpack.git"
   },
   "scripts": {
+    "tsc": "tsc",
     "postinstall": "node postinstall.js",
     "preuninstall": "node preuninstall.js",
     "postpack": "rm -rf node_modules",
-    "prepare": "tsc && npm run jasmine",
+    "prepare": "npm run tsc && npm run jasmine",
     "test": "npm run prepare && npm run jasmine",
     "jasmine": "jasmine --config=jasmine-config/jasmine.json",
     "version": "rm package-lock.json && conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md"
@@ -49,8 +50,8 @@
     "clean-webpack-plugin": "~1.0.0",
     "copy-webpack-plugin": "~4.6.0",
     "css-loader": "~2.1.1",
-    "fork-ts-checker-webpack-plugin": "1.3.0",
     "extra-watch-webpack-plugin": "1.0.3",
+    "fork-ts-checker-webpack-plugin": "1.3.0",
     "global-modules-path": "2.0.0",
     "minimatch": "3.0.4",
     "nativescript-hook": "0.2.4",

--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -32,7 +32,6 @@ module.exports = env => {
 
     // Default destination inside platforms/<platform>/...
     const dist = resolve(projectRoot, nsWebpack.getAppPath(platform, projectRoot));
-    const appResourcesPlatformDir = platform === "android" ? "Android" : "iOS";
 
     const {
         // The 'appPath' and 'appResourcesPath' values are fetched from

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -179,7 +179,7 @@ module.exports = env => {
                 },
 
                 {
-                    test: /-page\.js$/,
+                    test: /-page(\.(land|port|phone|tablet|minH\d+|minW\d+|minWH\d+))?\.js$/,
                     use: "nativescript-dev-webpack/script-hot-loader"
                 },
 

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -27,7 +27,6 @@ module.exports = env => {
 
     // Default destination inside platforms/<platform>/...
     const dist = resolve(projectRoot, nsWebpack.getAppPath(platform, projectRoot));
-    const appResourcesPlatformDir = platform === "android" ? "Android" : "iOS";
 
     const {
         // The 'appPath' and 'appResourcesPath' values are fetched from
@@ -179,18 +178,8 @@ module.exports = env => {
                 },
 
                 {
-                    test: /-page(\.(land|port|phone|tablet|minH\d+|minW\d+|minWH\d+))?\.js$/,
-                    use: "nativescript-dev-webpack/script-hot-loader"
-                },
-
-                {
-                    test: /\.(css|scss)$/,
-                    use: "nativescript-dev-webpack/style-hot-loader"
-                },
-
-                {
-                    test: /\.(html|xml)$/,
-                    use: "nativescript-dev-webpack/markup-hot-loader"
+                    test: /\.(js|css|scss|html|xml)$/,
+                    use: "nativescript-dev-webpack/hmr/hot-loader"
                 },
 
                 { test: /\.(html|xml)$/, use: "nativescript-dev-webpack/xml-namespace-loader" },

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -185,7 +185,7 @@ module.exports = env => {
                 },
 
                 {
-                    test: /-page\.ts$/,
+                    test: /-page(\.(land|port|phone|tablet|minH\d+|minW\d+|minWH\d+))?\.ts$/,
                     use: "nativescript-dev-webpack/script-hot-loader"
                 },
 

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -28,7 +28,6 @@ module.exports = env => {
 
     // Default destination inside platforms/<platform>/...
     const dist = resolve(projectRoot, nsWebpack.getAppPath(platform, projectRoot));
-    const appResourcesPlatformDir = platform === "android" ? "Android" : "iOS";
 
     const {
         // The 'appPath' and 'appResourcesPath' values are fetched from
@@ -183,20 +182,10 @@ module.exports = env => {
                         },
                     ].filter(loader => !!loader)
                 },
-
+                
                 {
-                    test: /-page(\.(land|port|phone|tablet|minH\d+|minW\d+|minWH\d+))?\.ts$/,
-                    use: "nativescript-dev-webpack/script-hot-loader"
-                },
-
-                {
-                    test: /\.(css|scss)$/,
-                    use: "nativescript-dev-webpack/style-hot-loader"
-                },
-
-                {
-                    test: /\.(html|xml)$/,
-                    use: "nativescript-dev-webpack/markup-hot-loader"
+                    test: /\.(ts|css|scss|html|xml)$/,
+                    use: "nativescript-dev-webpack/hmr/hot-loader"
                 },
 
                 { test: /\.(html|xml)$/, use: "nativescript-dev-webpack/xml-namespace-loader" },

--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -265,7 +265,7 @@ module.exports = env => {
     if (unitTesting) {
         config.module.rules.push(
             {
-                test: /-page\.js$/,
+                test: /-page(\.(land|port|phone|tablet|minH\d+|minW\d+|minWH\d+))?\.js$/,
                 use: "nativescript-dev-webpack/script-hot-loader"
             },
             {

--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -31,7 +31,6 @@ module.exports = env => {
 
     // Default destination inside platforms/<platform>/...
     const dist = resolve(projectRoot, nsWebpack.getAppPath(platform, projectRoot));
-    const appResourcesPlatformDir = platform === "android" ? "Android" : "iOS";
 
     const {
         // The 'appPath' and 'appResourcesPath' values are fetched from
@@ -265,7 +264,7 @@ module.exports = env => {
     if (unitTesting) {
         config.module.rules.push(
             {
-                test: /-page(\.(land|port|phone|tablet|minH\d+|minW\d+|minWH\d+))?\.js$/,
+                test: /-page\.js$/,
                 use: "nativescript-dev-webpack/script-hot-loader"
             },
             {


### PR DESCRIPTION
In this PR:
- Bundle config loader will add all `.xml`/`.js/ts`/`.css` files to the bundle (except files in the `App_Resources`). Previously it was only files with `-page` suffix.
- Added `hmr/hot-loader` which is used for JS and TS templates. It will process all `.xml`/`.js/ts`/`.css` files and it will add code that will enable HMR self-accept (`module.hot.accept()`) if the module was loaded from `tns-core-module/ui/builder` using the `global._isModuleLoadedForUI()` API from this PR: https://github.com/NativeScript/NativeScript/pull/7462
- bundle-config-loader and modules in `hmr/` folder converted to TypeScript

**Warning**: This PR should be merged together with his brother -> https://github.com/NativeScript/NativeScript/pull/7462

# Known Issue
If you have custom android application or activity it is pulled in the `bundle.js` by the `require.context`. You can exclude it by writing magical regex ([like this](https://github.com/NativeScript/nativescript-dev-webpack/blob/04df4742f25b808e135ed8f75969518396c7a092/demo/TypeScriptApp/webpack.config.js#L182)), but there might be an easier way to do it.


Related to #902 
