### PR TITLE
fix: require automatically only files from app folder of unit-test-runner

### DIFF
--- a/unit-testing-config-loader.js
+++ b/unit-testing-config-loader.js
@@ -4,7 +4,7 @@ const { convertSlashesInPath } = require("./projectHelpers");
 module.exports = function ({ appFullPath, projectRoot, angular, rootPagesRegExp }) {
     // TODO: Consider to use the files property from karma.conf.js
     const testFilesRegExp = /tests\/.*\.(ts|js)/;
-    const runnerFullPath = join(projectRoot, "node_modules", "nativescript-unit-test-runner");
+    const runnerFullPath = join(projectRoot, "node_modules", "nativescript-unit-test-runner", "app");
     const runnerRelativePath = convertSlashesInPath(relative(appFullPath, runnerFullPath));
     const appCssFilePath = convertSlashesInPath(join(runnerRelativePath, "app.css"));
     let source = `


### PR DESCRIPTION
Rel to: https://github.com/NativeScript/nativescript-unit-test-runner/pull/41
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla