### PR TITLE
fix: escape the regex for the path to the entry module of application

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const { existsSync } = require("fs");
+const escapeRegExp = require("escape-string-regexp");
 const { ANDROID_APP_PATH } = require("./androidProjectHelpers");
 const {
     getPackageJson,
@@ -62,8 +63,7 @@ exports.getAppPath = (platform, projectDir) => {
 
 exports.getEntryPathRegExp = (appFullPath, entryModule) => {
     const entryModuleFullPath = path.join(appFullPath, entryModule);
-    // Windows paths contain `\`, so we need to convert each of the `\` to `\\`, so it will be correct inside RegExp
-    const escapedPath = entryModuleFullPath.replace(/\\/g, "\\\\");
+    const escapedPath = escapeRegExp(entryModuleFullPath);
     return new RegExp(escapedPath);
 }
 

--- a/index.spec.ts
+++ b/index.spec.ts
@@ -61,7 +61,7 @@ describe('index', () => {
             path.join = originalPathJoin;
         });
 
-        it('returns RegExp that matches Windows', () => {
+        it('returns RegExp that works with Windows paths', () => {
             const appPath = "D:\\Work\\app1\\app";
             path.join = path.win32.join;
             const regExp = getEntryPathRegExp(appPath, entryModule);
@@ -70,6 +70,20 @@ describe('index', () => {
 
         it('returns RegExp that works with POSIX paths', () => {
             const appPath = "/usr/local/lib/app1/app";
+            path.join = path.posix.join;
+            const regExp = getEntryPathRegExp(appPath, entryModule);
+            expect(!!regExp.exec(`${appPath}/${entryModule}`)).toBe(true);
+        });
+
+        it('returns RegExp that works with Windows paths with special symbol in path', () => {
+            const appPath = "D:\\Work\\app1\\app (2)";
+            path.join = path.win32.join;
+            const regExp = getEntryPathRegExp(appPath, entryModule);
+            expect(!!regExp.exec(`${appPath}\\${entryModule}`)).toBe(true);
+        });
+
+        it('returns RegExp that works with POSIX paths with special symbol in path', () => {
+            const appPath = "/usr/local/lib/app1/app (2)";
             path.join = path.posix.join;
             const regExp = getEntryPathRegExp(appPath, entryModule);
             expect(!!regExp.exec(`${appPath}/${entryModule}`)).toBe(true);


### PR DESCRIPTION
Currently `bundle-config-loader` is not loaded when there is a special symbol in app's path. 
Rel to: https://github.com/NativeScript/nativescript-cli/issues/4844 

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla