### PR TITLE
refactor: remove the postinstall helper info

### DIFF
--- a/dependencyManager.js
+++ b/dependencyManager.js
@@ -10,17 +10,6 @@ Some dependencies have already been added. \
 If you want to force update them, please run "node_modules/.bin/update-ns-webpack".
 `;
 
-const USAGE_MESSAGE = `
-NativeScript Webpack plugin was successfully added.
-You can now bundle your project by passing --bundle flag to NativeScript CLI commands:
-    - tns build android --bundle
-    - tns build ios --bundle
-    - tns run android --bundle
-    - tns run ios --bundle
-You can also pass the "--env.uglify" flag to use Terser for minification.
-For more information check out https://docs.nativescript.org/tooling/bundling-with-webpack#bundling.
-`;
-
 function addProjectDeps(packageJson, force = false) {
     packageJson.devDependencies = packageJson.devDependencies || {};
     const postinstallOptions = {
@@ -105,8 +94,6 @@ function dependsOn(packageJson, package) {
 }
 
 function showHelperMessages({ newDepsAdded, hasOldDeps }) {
-    console.info(USAGE_MESSAGE);
-
     if (hasOldDeps) {
         console.info(ALREADY_ADDED_MESSAGE);
     }


### PR DESCRIPTION
The following helper message is displayed after installation of the
plugin:
```
NativeScript Webpack plugin was successfully added.
You can now bundle your project by passing --bundle flag to NativeScript CLI commands:
    - tns build android --bundle
    - tns build ios --bundle
    - tns run android --bundle
    - tns run ios --bundle
You can also pass the "--env.uglify" flag to use UglifyJS for minification.
For more information check out https://docs.nativescript.org/tooling/bundling-with-webpack#bundling.
```

With {N} 6.0, this message is not relevant any more:
1). the `bundle` flag is not needed for webpack builds;
2). the default build/run workflow uses webpack.
