### PR TITLE
fix: don't include partial scss files in bundle

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,8 @@
             "program": "${workspaceFolder}/node_modules/jasmine/bin/jasmine.js",
             "args": [
                 "--config=jasmine-config/jasmine.json"
-            ]
+            ],
+            "preLaunchTask": "npm:tsc"
         },
         {
             "type": "node",

--- a/bundle-config-loader.spec.ts
+++ b/bundle-config-loader.spec.ts
@@ -28,12 +28,17 @@ const defaultTestFiles = {
     "./main/main-page.land.ts": true,
     "./main/main-page-vm.ts": true,
 
-    "./package.json": false,
-    "./app.d.ts": false,
-    "./_app-common.scss": false,
-    "./_app-variables.scss": false,
-    "./App_Resources/Android/src/main/res/values/colors.xml": false,
-    "./App_Resources/Android/src/main/AndroidManifest.xml": false,
+    "./app_component.scss": true,
+    "./App_Resources123/some-file.xml": true,
+    "./MyApp_Resources/some-file.xml": true,
+    "./App_Resources_Nobody_Names_Folders_Like_That_Roska/some-file.xml": true,
+
+    "./package.json": false,          // do not include package.json files
+    "./app.d.ts": false,              // do not include ts definitions
+    "./_app-common.scss": false,      // do not include scss partial files
+    "./_app-variables.scss": false,   // do not include scss partial files
+    "./App_Resources/Android/src/main/res/values/colors.xml": false,    // do not include App_Resources
+    "./App_Resources/Android/src/main/AndroidManifest.xml": false,      // do not include App_Resources
 };
 
 const loaderOptionsWithIgnore = {
@@ -96,7 +101,7 @@ describe("BundleConfigLoader should create require.context", () => {
             callback: (error, source: string, map) => {
                 const regex = getRequireContextRegex(source);
                 const testFiles = { ...defaultTestFiles, ...ignoredTestFiles };
-                
+
                 assertTestFilesAreMatched(testFiles, regex);
 
                 done();

--- a/bundle-config-loader.spec.ts
+++ b/bundle-config-loader.spec.ts
@@ -1,0 +1,109 @@
+import bundleConfigLoader from "./bundle-config-loader";
+
+const defaultLoaderOptions = {
+    angular: false,
+    loadCss: true,
+    unitTesting: false,
+};
+
+const defaultTestFiles = {
+    "./app-root.xml": true,
+    "./app-root.land.xml": true,
+    "./app.ts": true,
+    "./app.css": true,
+    "./app.android.scss": true,
+    "./app.ios.scss": true,
+    "./app.land.css": true,
+    "./components/my-component.css": true,
+    "./components/my-component.land.ts": true,
+    "./components/my-component.ts": true,
+    "./components/my-component.land.xml": true,
+    "./components/my-component.xml": true,
+    "./components/my-component.land.css": true,
+    "./main/main-page.land.css": true,
+    "./main/main-page.css": true,
+    "./main/main-page.ts": true,
+    "./main/main-page.land.xml": true,
+    "./main/main-page.xml": true,
+    "./main/main-page.land.ts": true,
+    "./main/main-page-vm.ts": true,
+
+    "./package.json": false,
+    "./app.d.ts": false,
+    "./_app-common.scss": false,
+    "./_app-variables.scss": false,
+    "./App_Resources/Android/src/main/res/values/colors.xml": false,
+    "./App_Resources/Android/src/main/AndroidManifest.xml": false,
+};
+
+const loaderOptionsWithIgnore = {
+    angular: false,
+    loadCss: true,
+    unitTesting: false,
+    ignoredFiles: ["./application", "./activity"]
+};
+
+const ignoredTestFiles = {
+    "./application.ts": false,
+    "./activity.ts": false,
+}
+
+function getRequireContextRegex(source: string): RegExp {
+    const requireContextStr = `require.context("~/", true, `;
+
+    expect(source).toContain(requireContextStr);
+
+    const start = source.indexOf(requireContextStr) + requireContextStr.length;
+    const end = source.indexOf(");\n", start);
+    const regexStr = source.substring(start, end);
+    const regex: RegExp = eval(regexStr);
+
+    expect(regex instanceof RegExp).toBeTruthy();
+    return regex;
+}
+
+function assertTestFilesAreMatched(testFiles: { [key: string]: boolean }, regex: RegExp) {
+    for (let fileName in testFiles) {
+        if (defaultTestFiles[fileName]) {
+            expect(fileName).toMatch(regex);
+        }
+        else {
+            expect(fileName).not.toMatch(regex);
+        }
+    }
+}
+
+describe("BundleConfigLoader should create require.context", () => {
+    it("default case", (done) => {
+
+        const loaderContext = {
+            callback: (error, source: string, map) => {
+                const regex = getRequireContextRegex(source);
+
+                assertTestFilesAreMatched(defaultTestFiles, regex);
+
+                done();
+            },
+            query: defaultLoaderOptions
+        }
+
+        bundleConfigLoader.call(loaderContext, " ___CODE___");
+    })
+
+    it("with ignored files", (done) => {
+
+        const loaderContext = {
+            callback: (error, source: string, map) => {
+                const regex = getRequireContextRegex(source);
+                const testFiles = { ...defaultTestFiles, ...ignoredTestFiles };
+                
+                assertTestFilesAreMatched(testFiles, regex);
+
+                done();
+            },
+            query: loaderOptionsWithIgnore
+        }
+
+        bundleConfigLoader.call(loaderContext, " ___CODE___");
+    })
+});

--- a/bundle-config-loader.ts
+++ b/bundle-config-loader.ts
@@ -4,7 +4,7 @@ import { getOptions } from "loader-utils";
 import * as escapeRegExp from "escape-string-regexp";
 
 // Matches all source, markup and style files that are not in App_Resources
-const defaultMatch = "(?<!App_Resources.*)\.(xml|css|js|(?<!d\.)ts|scss)$";
+const defaultMatch = "(?<!App_Resources.*)\\.(xml|css|js|(?<!\\.d\\.)ts|(?<!_[\\w-]*\\.)scss)$";
 
 const loader: loader.Loader = function (source, map) {
     let {

--- a/bundle-config-loader.ts
+++ b/bundle-config-loader.ts
@@ -4,7 +4,7 @@ import { getOptions } from "loader-utils";
 import * as escapeRegExp from "escape-string-regexp";
 
 // Matches all source, markup and style files that are not in App_Resources
-const defaultMatch = "(?<!App_Resources.*)\\.(xml|css|js|(?<!\\.d\\.)ts|(?<!_[\\w-]*\\.)scss)$";
+const defaultMatch = "(?<!\\bApp_Resources\\b.*)\\.(xml|css|js|(?<!\\.d\\.)ts|(?<!\\b_[\\w-]*\\.)scss)$";
 
 const loader: loader.Loader = function (source, map) {
     let {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "preuninstall": "node preuninstall.js",
     "postpack": "rm -rf node_modules",
     "prepare": "npm run tsc && npm run jasmine",
-    "test": "npm run prepare && npm run jasmine",
+    "test": "npm run prepare",
     "jasmine": "jasmine --config=jasmine-config/jasmine.json",
     "version": "rm package-lock.json && conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md"
   },


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [x] Tests for the changes are included.

## What is the current behavior?
Partial `.scss` are included in the bundle by `BundleConfigLoader`.

## What is the new behavior?
Partial `.scss` are **not** included in the bundle by `BundleConfigLoader`.

