### PR TITLE
[Don't Merge]refactor: LoadCss no longer needed for JS/TS projects

### DIFF
--- a/bundle-config-loader.ts
+++ b/bundle-config-loader.ts
@@ -9,7 +9,7 @@ const defaultMatch = "(?<!App_Resources.*)\.(xml|css|js|(?<!d\.)ts|scss)$";
 const loader: loader.Loader = function (source, map) {
     let {
         angular = false,
-        loadCss = true,
+        loadCss = false, // explicit load of app.css is needed only for vue and angular
         unitTesting,
         projectRoot,
         appFullPath,

--- a/demo/JavaScriptApp/webpack.config.js
+++ b/demo/JavaScriptApp/webpack.config.js
@@ -170,7 +170,6 @@ module.exports = env => {
                         {
                             loader: "nativescript-dev-webpack/bundle-config-loader",
                             options: {
-                                loadCss: !snapshot, // load the application css if in debug mode
                                 unitTesting,
                                 appFullPath,
                                 projectRoot,

--- a/demo/TypeScriptApp/webpack.config.js
+++ b/demo/TypeScriptApp/webpack.config.js
@@ -176,7 +176,6 @@ module.exports = env => {
                         {
                             loader: "nativescript-dev-webpack/bundle-config-loader",
                             options: {
-                                loadCss: !snapshot, // load the application css if in debug mode
                                 unitTesting,
                                 appFullPath,
                                 projectRoot,

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -170,7 +170,6 @@ module.exports = env => {
                         {
                             loader: "nativescript-dev-webpack/bundle-config-loader",
                             options: {
-                                loadCss: !snapshot, // load the application css if in debug mode
                                 unitTesting,
                                 appFullPath,
                                 projectRoot,

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -175,7 +175,6 @@ module.exports = env => {
                         {
                             loader: "nativescript-dev-webpack/bundle-config-loader",
                             options: {
-                                loadCss: !snapshot, // load the application css if in debug mode
                                 unitTesting,
                                 appFullPath,
                                 projectRoot,

--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -181,7 +181,6 @@ module.exports = env => {
                     {
                         loader: "nativescript-dev-webpack/bundle-config-loader",
                         options: {
-                            registerPages: true, // applicable only for non-angular apps
                             loadCss: !snapshot, // load the application css if in debug mode
                             unitTesting,
                             appFullPath,


### PR DESCRIPTION
The `loadCss` flag is no longer needed for JS/TS projects. It explicitly loads `app.[s]css` files in the app with `require.context`. However they are already loaded by bundle config loader. 