### PR TITLE
fix: vue template crashes on start

### DIFF
--- a/demo/AngularApp/webpack.config.js
+++ b/demo/AngularApp/webpack.config.js
@@ -198,7 +198,7 @@ module.exports = env => {
         module: {
             rules: [
                 {
-                    test: nsWebpack.getEntryPathRegExp(appFullPath, entryPath),
+                    include: join(appFullPath, entryPath),
                     use: [
                         // Require all Android app components
                         platform === "android" && {

--- a/demo/JavaScriptApp/webpack.config.js
+++ b/demo/JavaScriptApp/webpack.config.js
@@ -159,7 +159,7 @@ module.exports = env => {
         module: {
             rules: [
                 {
-                    test: nsWebpack.getEntryPathRegExp(appFullPath, entryPath),
+                    include: join(appFullPath, entryPath),
                     use: [
                         // Require all Android app components
                         platform === "android" && {

--- a/demo/TypeScriptApp/webpack.config.js
+++ b/demo/TypeScriptApp/webpack.config.js
@@ -165,7 +165,7 @@ module.exports = env => {
         module: {
             rules: [
                 {
-                    test: nsWebpack.getEntryPathRegExp(appFullPath, entryPath),
+                    include: join(appFullPath, entryPath),
                     use: [
                         // Require all Android app components
                         platform === "android" && {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 const path = require("path");
 const { existsSync } = require("fs");
-const escapeRegExp = require("escape-string-regexp");
 const { ANDROID_APP_PATH } = require("./androidProjectHelpers");
 const {
     getPackageJson,
@@ -60,12 +59,6 @@ exports.getAppPath = (platform, projectDir) => {
         throw new Error(`Invalid platform: ${platform}`);
     }
 };
-
-exports.getEntryPathRegExp = (appFullPath, entryModule) => {
-    const entryModuleFullPath = path.join(appFullPath, entryModule);
-    const escapedPath = escapeRegExp(entryModuleFullPath);
-    return new RegExp(escapedPath);
-}
 
 exports.getSourceMapFilename = (hiddenSourceMap, appFolderPath, outputPath) => {
     const appFolderRelativePath = path.join(path.relative(outputPath, appFolderPath));

--- a/index.spec.ts
+++ b/index.spec.ts
@@ -1,5 +1,4 @@
-import { getConvertedExternals, getEntryPathRegExp } from './index';
-const path = require("path");
+import { getConvertedExternals } from './index';
 
 describe('index', () => {
     describe('getConvertedExternals', () => {
@@ -50,43 +49,6 @@ describe('index', () => {
                     expect(result).toBe(false, `String ${testString} matches some of the regular expressions: ${regExpsExternals.join(', ')}`);
                 });
             });
-        });
-    });
-
-    describe('getEntryPathRegExp', () => {
-        const originalPathJoin = path.join;
-        const entryModule = "index.js";
-
-        afterEach(() => {
-            path.join = originalPathJoin;
-        });
-
-        it('returns RegExp that works with Windows paths', () => {
-            const appPath = "D:\\Work\\app1\\app";
-            path.join = path.win32.join;
-            const regExp = getEntryPathRegExp(appPath, entryModule);
-            expect(!!regExp.exec(`${appPath}\\${entryModule}`)).toBe(true);
-        });
-
-        it('returns RegExp that works with POSIX paths', () => {
-            const appPath = "/usr/local/lib/app1/app";
-            path.join = path.posix.join;
-            const regExp = getEntryPathRegExp(appPath, entryModule);
-            expect(!!regExp.exec(`${appPath}/${entryModule}`)).toBe(true);
-        });
-
-        it('returns RegExp that works with Windows paths with special symbol in path', () => {
-            const appPath = "D:\\Work\\app1\\app (2)";
-            path.join = path.win32.join;
-            const regExp = getEntryPathRegExp(appPath, entryModule);
-            expect(!!regExp.exec(`${appPath}\\${entryModule}`)).toBe(true);
-        });
-
-        it('returns RegExp that works with POSIX paths with special symbol in path', () => {
-            const appPath = "/usr/local/lib/app1/app (2)";
-            path.join = path.posix.join;
-            const regExp = getEntryPathRegExp(appPath, entryModule);
-            expect(!!regExp.exec(`${appPath}/${entryModule}`)).toBe(true);
         });
     });
 });

--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -197,7 +197,7 @@ module.exports = env => {
         module: {
             rules: [
                 {
-                    test: nsWebpack.getEntryPathRegExp(appFullPath, entryPath),
+                    include: join(appFullPath, entryPath),
                     use: [
                         // Require all Android app components
                         platform === "android" && {

--- a/templates/webpack.config.spec.ts
+++ b/templates/webpack.config.spec.ts
@@ -31,7 +31,6 @@ const nativeScriptDevWebpack = {
     getAppPath: () => 'app',
     getEntryModule: () => 'EntryModule',
     getResolver: () => null,
-    getEntryPathRegExp: () => null,
     getConvertedExternals: nsWebpackIndex.getConvertedExternals,
     getSourceMapFilename: nsWebpackIndex.getSourceMapFilename
 };

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -161,7 +161,7 @@ module.exports = env => {
         module: {
             rules: [
                 {
-                    test: nsWebpack.getEntryPathRegExp(appFullPath, entryPath),
+                    include: join(appFullPath, entryPath),
                     use: [
                         // Require all Android app components
                         platform === "android" && {

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -164,7 +164,7 @@ module.exports = env => {
         module: {
             rules: [
                 {
-                    test: nsWebpack.getEntryPathRegExp(appFullPath, entryPath),
+                    include: join(appFullPath, entryPath),
                     use: [
                         // Require all Android app components
                         platform === "android" && {

--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -170,7 +170,7 @@ module.exports = env => {
         },
         module: {
             rules: [{
-                test: nsWebpack.getEntryPathRegExp(appFullPath, entryPath + ".(js|ts)"),
+                include: [join(appFullPath, entryPath + ".js"), join(appFullPath, entryPath + ".ts")],
                 use: [
                     // Require all Android app components
                     platform === "android" && {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently the app crashes as the entry module is not resolved.

## What is the new behavior?
<!-- Describe the changes. -->
The app is working as expected and there are no escaping RegEx reserved symbols from path.

Rel to: https://github.com/NativeScript/nativescript-dev-webpack/issues/998

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla