### PR TITLE
fix: restore getEntryPathRegExp for backward compatibility with older…

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,18 @@ exports.getAppPath = (platform, projectDir) => {
     }
 };
 
+/**
+ * For backward compatibility. This method is deprecated. Do not use it anymore.
+ * This method also has a bug of not escaping valid regex symbols in entry path.
+ * For module rules use: "include" instead of "test".
+ */
+exports.getEntryPathRegExp = (appFullPath, entryModule) => {
+    const entryModuleFullPath = path.join(appFullPath, entryModule);
+    // Windows paths contain `\`, so we need to convert each of the `\` to `\\`, so it will be correct inside RegExp
+    const escapedPath = entryModuleFullPath.replace(/\\/g, "\\\\");
+    return new RegExp(escapedPath);
+}
+
 exports.getSourceMapFilename = (hiddenSourceMap, appFolderPath, outputPath) => {
     const appFolderRelativePath = path.join(path.relative(outputPath, appFolderPath));
     let sourceMapFilename = "[file].map";


### PR DESCRIPTION
… webpack.config.js

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If the user doesn't update `webpack.config.js`, build fails.

## What is the new behavior?
<!-- Describe the changes. -->
If the user doesn't update `webpack.config.js`, build succeeds.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla