### PR TITLE
fix(update-ns-webpack): skip the update of tsconfig.tns.json in shared Angular projects

### DIFF
--- a/projectFilesManager.js
+++ b/projectFilesManager.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const fs = require("fs");
 
-const { isTypeScript, isAngular, isVue } = require("./projectHelpers");
+const { isTypeScript, isAngular, isVue, isShared } = require("./projectHelpers");
 
 function addProjectFiles(projectDir) {
     const projectTemplates = getProjectTemplates(projectDir);
@@ -62,7 +62,11 @@ function getProjectTemplates(projectDir) {
 
     let templates;
     if (isAngular({ projectDir })) {
-        templates = getAngularTemplates(WEBPACK_CONFIG_NAME, TSCONFIG_TNS_NAME);
+        if (isShared({ projectDir })) {
+            templates = getSharedAngularTemplates(WEBPACK_CONFIG_NAME);
+        } else {
+            templates = getAngularTemplates(WEBPACK_CONFIG_NAME, TSCONFIG_TNS_NAME);
+        }
     } else if (isVue({ projectDir })) {
         templates = getVueTemplates(WEBPACK_CONFIG_NAME);
     } else if (isTypeScript({ projectDir })) {
@@ -72,6 +76,12 @@ function getProjectTemplates(projectDir) {
     }
 
     return getFullTemplatesPath(projectDir, templates);
+}
+
+function getSharedAngularTemplates(webpackConfigName) {
+    return {
+        "webpack.angular.js": webpackConfigName,
+    };
 }
 
 function getAngularTemplates(webpackConfigName, tsconfigName) {

--- a/projectHelpers.js
+++ b/projectHelpers.js
@@ -17,6 +17,11 @@ const isTypeScript = ({ projectDir, packageJson } = {}) => {
         ) || isAngular({ packageJson });
 };
 
+const isShared = ({ projectDir }) => {
+    const nsConfig = getNsConfig(projectDir);
+    return nsConfig && !!nsConfig.shared;
+}
+
 const isAngular = ({ projectDir, packageJson } = {}) => {
     packageJson = packageJson || getPackageJson(projectDir);
 
@@ -39,9 +44,22 @@ const isVue = ({ projectDir, packageJson } = {}) => {
 
 const getPackageJson = projectDir => {
     const packageJsonPath = getPackageJsonPath(projectDir);
+    const result = readJsonFile(packageJsonPath);
+
+    return result;
+};
+
+const getNsConfig = projectDir => {
+    const nsConfigPath = getNsConfigPath(projectDir);
+    const result = readJsonFile(nsConfigPath);
+
+    return result;
+};
+
+const readJsonFile = filePath => {
     let result;
     try {
-        result = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+        result = JSON.parse(fs.readFileSync(filePath, "utf8"));
     } catch (e) {
         result = {};
     }
@@ -69,6 +87,7 @@ const getIndentationCharacter = (jsonContent) => {
 const getProjectDir = hook.findProjectDir;
 
 const getPackageJsonPath = projectDir => resolve(projectDir, "package.json");
+const getNsConfigPath = projectDir => resolve(projectDir, "nsconfig.json");
 
 const isAndroid = platform => /android/i.test(platform);
 const isIos = platform => /ios/i.test(platform);
@@ -104,6 +123,7 @@ module.exports = {
     isAndroid,
     isIos,
     isAngular,
+    isShared,
     getAngularVersion,
     isVue,
     isTypeScript,
@@ -112,3 +132,4 @@ module.exports = {
     getIndentationCharacter,
     safeGet,
 };
+


### PR DESCRIPTION
The NativeScript Angular code-sharing projects, built with the
[recommended structure](https://docs.nativescript.org/angular/code-sharing/intro), have a different `tsconfig.tns.json` file
compared to the rest of the {N} project flavors. The update script,
distributed by the `nativescript-dev-webpack` plugin shouldn't override
that file when executed in a code-sharing project.