### PR TITLE
fix: avoid getting invalid require calls when building from Windows

### DIFF
--- a/plugins/GenerateNativeScriptEntryPointsPlugin.js
+++ b/plugins/GenerateNativeScriptEntryPointsPlugin.js
@@ -1,3 +1,4 @@
+const { convertToUnixPath } = require("../lib/utils");
 const { RawSource } = require("webpack-sources");
 const { getPackageJson } = require("../projectHelpers");
 const { SNAPSHOT_ENTRY_NAME } = require("./NativeScriptSnapshotPlugin");
@@ -77,8 +78,9 @@ exports.GenerateNativeScriptEntryPointsPlugin = (function () {
 
                 const requireDeps = requiredFiles.map(depPath => {
                     const depRelativePath = path.join(pathToRootFromCurrFile, depPath);
+                    const depRelativePathUnix = convertToUnixPath(depRelativePath);
 
-                    return `require("./${depRelativePath}");`;
+                    return `require("./${depRelativePathUnix}");`;
                 }).join("");
                 const currentEntryFileContent = compilation.assets[filePath].source();
                 compilation.assets[filePath] = new RawSource(`${requireDeps}${currentEntryFileContent}`);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

Related to: https://github.com/NativeScript/nativescript-dev-webpack/issues/989#issuecomment-514253061