### PR TITLE
fix: require dependencies only in sourceFiles (avoid getting invalid `.js.map` files)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-dev-webpack",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "index",
   "description": "",
   "homepage": "http://www.telerik.com",

--- a/plugins/GenerateNativeScriptEntryPointsPlugin.js
+++ b/plugins/GenerateNativeScriptEntryPointsPlugin.js
@@ -72,7 +72,7 @@ exports.GenerateNativeScriptEntryPointsPlugin = (function () {
                 throw new Error(`${GenerationFailedError} File "${filePath}" not found for entry "${entryPointName}".`);
             }
 
-            if (!this.isHMRFile(filePath)) {
+            if (!this.isHMRFile(filePath) && this.isSourceFile(filePath)) {
                 const currFileDirRelativePath = path.dirname(filePath);
                 const pathToRootFromCurrFile = path.relative(currFileDirRelativePath, ".");
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

Related to: https://github.com/NativeScript/nativescript-dev-webpack/issues/968#issuecomment-514581546