### PR TITLE
refactor: remove obsolete comment including the `--bundle flag`

### DIFF
--- a/demo/AngularApp/webpack.config.js
+++ b/demo/AngularApp/webpack.config.js
@@ -37,7 +37,6 @@ module.exports = env => {
     const {
         // The 'appPath' and 'appResourcesPath' values are fetched from
         // the nsconfig.json configuration file
-        // when bundling with `tns run android|ios --bundle`.
         appPath = "src",
         appResourcesPath = "App_Resources",
 

--- a/demo/JavaScriptApp/webpack.config.js
+++ b/demo/JavaScriptApp/webpack.config.js
@@ -32,7 +32,6 @@ module.exports = env => {
     const {
         // The 'appPath' and 'appResourcesPath' values are fetched from
         // the nsconfig.json configuration file
-        // when bundling with `tns run android|ios --bundle`.
         appPath = "app",
         appResourcesPath = "app/App_Resources",
 

--- a/demo/TypeScriptApp/webpack.config.js
+++ b/demo/TypeScriptApp/webpack.config.js
@@ -33,7 +33,6 @@ module.exports = env => {
     const {
         // The 'appPath' and 'appResourcesPath' values are fetched from
         // the nsconfig.json configuration file
-        // when bundling with `tns run android|ios --bundle`.
         appPath = "app",
         appResourcesPath = "app/App_Resources",
 

--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -36,7 +36,6 @@ module.exports = env => {
     const {
         // The 'appPath' and 'appResourcesPath' values are fetched from
         // the nsconfig.json configuration file
-        // when bundling with `tns run android|ios --bundle`.
         appPath = "src",
         appResourcesPath = "App_Resources",
 

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -31,7 +31,6 @@ module.exports = env => {
     const {
         // The 'appPath' and 'appResourcesPath' values are fetched from
         // the nsconfig.json configuration file
-        // when bundling with `tns run android|ios --bundle`.
         appPath = "app",
         appResourcesPath = "app/App_Resources",
 

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -32,7 +32,6 @@ module.exports = env => {
     const {
         // The 'appPath' and 'appResourcesPath' values are fetched from
         // the nsconfig.json configuration file
-        // when bundling with `tns run android|ios --bundle`.
         appPath = "app",
         appResourcesPath = "app/App_Resources",
 

--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -35,7 +35,6 @@ module.exports = env => {
     const {
         // The 'appPath' and 'appResourcesPath' values are fetched from
         // the nsconfig.json configuration file
-        // when bundling with `tns run android|ios --bundle`.
         appPath = "app",
         appResourcesPath = "app/App_Resources",
 


### PR DESCRIPTION
The webpack configurations contain an obsolete comment which is no
longer needed since {N} 6.0 is webpack-only.