### PR TITLE
fix: register non-relative app.css module

### DIFF
--- a/load-application-css-angular.js
+++ b/load-application-css-angular.js
@@ -3,5 +3,6 @@ const loadCss = require("./load-application-css");
 module.exports = function() {
     loadCss(function() {
         global.registerModule("./app.css", () => require("~/app"));
+        global.registerModule("app.css", () => require("~/app"));
     });
 }


### PR DESCRIPTION
Since https://github.com/NativeScript/NativeScript/pull/7631 the `tns-core-modules` now looks for `app.css` package to load (instead of `./app.css`) for loading the global css file.

BREAKING CHANGES:
This might be a breaking change for folks using custom `app.css` file using approach described in  https://github.com/NativeScript/nativescript-dev-webpack/issues/587. The fix would be to do `global.registerModule("app.css", () => require("~/app1.css"));`