### PR TITLE
fix: add ia64 as supported architecture

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-dev-webpack",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "index",
   "description": "",
   "homepage": "http://www.telerik.com",

--- a/plugins/NativeScriptSnapshotPlugin/options.json
+++ b/plugins/NativeScriptSnapshotPlugin/options.json
@@ -28,14 +28,16 @@
       "default": [
         "arm",
         "arm64",
-        "ia32"
+        "ia32",
+        "ia64"
       ],
       "items": {
         "type": "string",
         "enum": [
           "arm",
           "arm64",
-          "ia32"
+          "ia32",
+          "ia64"
         ]
       }
     },

--- a/snapshot/android/project-snapshot-generator.js
+++ b/snapshot/android/project-snapshot-generator.js
@@ -239,7 +239,7 @@ ProjectSnapshotGenerator.prototype.generate = function (generationOptions) {
 
         const options = {
             snapshotToolsPath,
-            targetArchs: generationOptions.targetArchs || ["arm", "arm64", "ia32"],
+            targetArchs: generationOptions.targetArchs || ["arm", "arm64", "ia32", "ia64"],
             v8Version: generationOptions.v8Version || v8Version,
             preprocessedInputFile: generationOptions.preprocessedInputFile,
             useLibs: generationOptions.useLibs || false,

--- a/snapshot/android/project-snapshot-generator.js
+++ b/snapshot/android/project-snapshot-generator.js
@@ -237,9 +237,18 @@ ProjectSnapshotGenerator.prototype.generate = function (generationOptions) {
             throw new Error(noV8VersionFoundMessage);
         }
 
+        // NOTE: Order is important! Add new archs at the end of the array
+        const defaultTargetArchs = ["arm", "arm64", "ia32", "ia64"];
+        const runtimeVersion = getAndroidRuntimeVersion(this.options.projectRoot);
+        if (runtimeVersion && semver.lt(semver.coerce(runtimeVersion), "6.0.2")) {
+            const indexOfIa64 = defaultTargetArchs.indexOf("ia64");
+            // Before 6.0.2 version of Android runtime we supported only arm, arm64 and ia32.
+            defaultTargetArchs.splice(indexOfIa64, defaultTargetArchs.length - indexOfIa64);
+        }
+
         const options = {
             snapshotToolsPath,
-            targetArchs: generationOptions.targetArchs || ["arm", "arm64", "ia32", "ia64"],
+            targetArchs: generationOptions.targetArchs || defaultTargetArchs,
             v8Version: generationOptions.v8Version || v8Version,
             preprocessedInputFile: generationOptions.preprocessedInputFile,
             useLibs: generationOptions.useLibs || false,

--- a/snapshot/android/snapshot-generator.js
+++ b/snapshot/android/snapshot-generator.js
@@ -102,7 +102,6 @@ SnapshotGenerator.prototype.convertToAndroidArchName = function (archName) {
         case "arm64": return "arm64-v8a";
         case "ia32": return "x86";
         case "ia64": return "x86_64";
-        case "x64": return "x64";
         default: return archName;
     }
 }

--- a/snapshot/android/snapshot-generator.js
+++ b/snapshot/android/snapshot-generator.js
@@ -53,7 +53,7 @@ SnapshotGenerator.prototype.preprocessInputFiles = function (inputFiles, outputF
     // Example:
     // (function() {
     //  some code here
-    //  })() 
+    //  })()
     //  // sourceMapUrl......
     //  ** when we join without `;` here, the next IIFE is assumed as a function call to the result of the first IIFE
     // (function() {
@@ -101,6 +101,7 @@ SnapshotGenerator.prototype.convertToAndroidArchName = function (archName) {
         case "arm": return "armeabi-v7a";
         case "arm64": return "arm64-v8a";
         case "ia32": return "x86";
+        case "ia64": return "x86_64";
         case "x64": return "x64";
         default: return archName;
     }


### PR DESCRIPTION
Add ia64 as supported architecture and map it to x86_64 Android arch.
NOTE: use ia64 only if runtime is 6.0.2 or later  …
Older runtimes cannot work with ia64 arch (they do not have the x86_64 arch), so check the runtime version and remove the ia64 (and all new archs that we may add in the future).
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
You cannot use snapshot for building ia64 version (x86_64).

## What is the new behavior?
In case Android runtime version is 6.0.2 or later, ia64 (x86_64) snapshot will be automatically built.

Related to https://github.com/NativeScript/nativescript-dev-webpack/issues/1030 and NativeScript/nativescript-cli#4330

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla