### PR TITLE
fix: stop generating snapshot for ia64 for older runtimes

### DIFF
--- a/plugins/NativeScriptSnapshotPlugin/options.json
+++ b/plugins/NativeScriptSnapshotPlugin/options.json
@@ -25,12 +25,6 @@
     },
     "targetArchs": {
       "type": "array",
-      "default": [
-        "arm",
-        "arm64",
-        "ia32",
-        "ia64"
-      ],
       "items": {
         "type": "string",
         "enum": [


### PR DESCRIPTION
When the runtime version is below 6.0.2 we should generate snapshot only for armv7, arm64 and ia32 archs. However, as in the validation schema we have default value for the targetArchs, the logic that should determine if ia64 should be removed from the targetArchs decides the archs are passed by the user and does not strip anything from them. Remove the default values from the JSON Schema - they are calculated in the code, so there's no need to have them on two places. As we can not have our conditional logic in the JSON schema, keep calculation of the default values only in the code.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
When Runtime 6.0.1 is used, snapshots are generated for 4 architectures. The ia64 is invalid.

## What is the new behavior?
When Runtime 6.0.1 is used, snapshots are generated for 3 architectures. 

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla