### PR TITLE
chore: Enable all unit test and test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,6 @@ bundle-config-loader.js
 
 hooks
 .DS_Store
-
+.nyc_output
+coverage
 !projectHelpers.spec.js

--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,8 @@ demo
 *.spec.*
 .vscode/
 .github/
+.nyc_output
+coverage/
 jasmine-config/
 CONTRIBUTING.md
 CODE_OF_CONDUCT.md

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,5 @@
+{
+    "extends": "@istanbuljs/nyc-config-typescript",
+    "exclude": ["/demo/**"],
+    "reporter": ["text", "lcov"]
+}

--- a/jasmine-config/jasmine.json
+++ b/jasmine-config/jasmine.json
@@ -3,7 +3,7 @@
   "spec_files": [
 	"!node_modules/**/*.spec.js",
 	"!demo/**/*.spec.js",
-	"./*.spec.js"
+	"./**/*.spec.js"
   ],
   "helpers": [
     "jasmine-config/**/*.js"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "prepare": "npm run tsc && npm run jasmine",
     "test": "npm run prepare",
     "jasmine": "jasmine --config=jasmine-config/jasmine.json",
+    "coverage": "nyc npm run test",
     "version": "rm package-lock.json && conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md"
   },
   "bin": {
@@ -77,6 +78,7 @@
   "devDependencies": {
     "@angular/compiler": "8.2.0",
     "@angular/compiler-cli": "8.2.0",
+    "@istanbuljs/nyc-config-typescript": "^0.1.3",
     "@ngtools/webpack": "8.2.0",
     "@types/jasmine": "^3.3.7",
     "@types/loader-utils": "^1.1.3",
@@ -87,7 +89,9 @@
     "conventional-changelog-cli": "^1.3.22",
     "jasmine": "^3.2.0",
     "jasmine-spec-reporter": "^4.2.1",
+    "nyc": "^14.1.1",
     "proxyquire": "2.1.0",
+    "source-map-support": "^0.5.13",
     "tns-core-modules": "next",
     "typescript": "~3.5.3"
   }

--- a/templates/webpack.config.spec.ts
+++ b/templates/webpack.config.spec.ts
@@ -37,8 +37,6 @@ const nativeScriptDevWebpack = {
     getUserDefinedEntries: nsWebpackIndex.getUserDefinedEntries,
 };
 
-
-
 const emptyObject = {};
 const FakeAotTransformerFlag = "aot";
 const FakeHmrTransformerFlag = "hmr";

--- a/templates/webpack.config.spec.ts
+++ b/templates/webpack.config.spec.ts
@@ -32,8 +32,12 @@ const nativeScriptDevWebpack = {
     getEntryModule: () => 'EntryModule',
     getResolver: () => null,
     getConvertedExternals: nsWebpackIndex.getConvertedExternals,
-    getSourceMapFilename: nsWebpackIndex.getSourceMapFilename
+    getSourceMapFilename: nsWebpackIndex.getSourceMapFilename,
+    processAppComponents: nsWebpackIndex.processAppComponents,
+    getUserDefinedEntries: nsWebpackIndex.getUserDefinedEntries,
 };
+
+
 
 const emptyObject = {};
 const FakeAotTransformerFlag = "aot";


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [x] Tests for the changes are included.

## What is the current behavior?
Only tests in the root of the repo were executed with `npm test`

## What is the new behavior?
- All tests (including nested folders) are executed with `npm tests`
- Added `npm run coverage` that will report code-coverage using `nyc` (a.k.a. "the new istanbuljs")

