### PR TITLE
feat: support V8 snapshots on Windows

### DIFF
--- a/lib/before-checkForChanges.js
+++ b/lib/before-checkForChanges.js
@@ -1,6 +1,11 @@
+const { shouldSnapshot, isWinOS } = require("./utils");
+const semver = require("semver");
+
 module.exports = function ($staticConfig, hookArgs) {
-    const majorVersionMatch = ($staticConfig.version || '').match(/^(\d+)\./);
-    const majorVersion = majorVersionMatch && majorVersionMatch[1] && +majorVersionMatch[1];
+    const cliVersion = semver.parse($staticConfig.version);
+    const majorVersion = cliVersion && cliVersion.major;
+    const minorVersion = cliVersion && cliVersion.minor;
+
     if (majorVersion && majorVersion < 6) {
         // check if we are using the bundle workflow or the legacy one.
         const isUsingBundleWorkflow = hookArgs &&
@@ -11,6 +16,18 @@ module.exports = function ($staticConfig, hookArgs) {
         if (isUsingBundleWorkflow) {
             const packageJsonData = require("../package.json")
             throw new Error(`The current version of ${packageJsonData.name} (${packageJsonData.version}) is not compatible with the used CLI: ${$staticConfig.version}. Please upgrade your NativeScript CLI version (npm i -g nativescript).`);
+        }
+    } else {
+        const env = hookArgs.prepareData.env || {};
+        const shouldSnapshotOptions = {
+            platform: hookArgs.prepareData.platform,
+            release: hookArgs.prepareData.release
+        };
+
+        const shouldSnapshotOnWin = env.snapshot && shouldSnapshot(shouldSnapshotOptions) && isWinOS();
+        const isCLIWithoutWinSnapshotsSupport = majorVersion && majorVersion == 6 && minorVersion && minorVersion < 2;
+        if (shouldSnapshotOnWin && isCLIWithoutWinSnapshotsSupport) {
+            throw new Error(`In order to generate Snapshots on Windows, please upgrade your NativeScript CLI version (npm i -g nativescript).`);
         }
     }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,9 +3,8 @@ const { isAndroid } = require("../projectHelpers");
 
 function shouldSnapshot(config) {
     const platformSupportsSnapshot = isAndroid(config.platform);
-    const osSupportsSnapshot = os.type() !== "Windows_NT";
 
-    return config.release && platformSupportsSnapshot && osSupportsSnapshot;
+    return config.release && platformSupportsSnapshot;
 }
 
 function convertToUnixPath(relativePath) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,7 +11,12 @@ function convertToUnixPath(relativePath) {
     return relativePath.replace(/\\/g, "/");
 }
 
+function isWinOS() {
+    return os.type() === "Windows_NT";
+}
+
 module.exports = {
     shouldSnapshot,
-    convertToUnixPath
+    convertToUnixPath,
+    isWinOS
 };

--- a/snapshot/android/project-snapshot-generator.js
+++ b/snapshot/android/project-snapshot-generator.js
@@ -1,4 +1,4 @@
-const { dirname, isAbsolute, join, resolve } = require("path");
+const { dirname, isAbsolute, join, resolve, sep } = require("path");
 const { existsSync, readFileSync, writeFileSync } = require("fs");
 
 const shelljs = require("shelljs");
@@ -102,7 +102,7 @@ ProjectSnapshotGenerator.installSnapshotArtefacts = function (projectRoot) {
 
         // Copy the libs to the specified destination in the platforms folder
         shelljs.mkdir("-p", libsDestinationPath);
-        shelljs.cp("-R", join(buildPath, "ndk-build/libs") + "/", libsDestinationPath);
+        shelljs.cp("-R", join(buildPath, "ndk-build/libs") + sep, libsDestinationPath);
     } else {
         // useLibs = false
         const blobsSrcPath = join(buildPath, "snapshots/blobs");
@@ -110,14 +110,7 @@ ProjectSnapshotGenerator.installSnapshotArtefacts = function (projectRoot) {
         const appPackageJsonPath = join(appPath, "package.json");
 
         // Copy the blobs in the prepared app folder
-        shelljs.cp("-R", blobsSrcPath + "/", resolve(appPath, "../snapshots"));
-
-        /*
-        Rename TNSSnapshot.blob files to snapshot.blob files. The xxd tool uses the file name for the name of the static array. 
-        This is why the *.blob files are initially named  TNSSnapshot.blob. 
-        After the xxd step, they must be renamed to snapshot.blob, because this is the filename that the Android runtime is looking for.
-        */
-        shelljs.exec("find " + blobsDestinationPath + " -name '*.blob' -execdir mv {} snapshot.blob ';'");
+        shelljs.cp("-R", blobsSrcPath + sep, resolve(appPath, "../snapshots"));
 
         // Update the package.json file
         const appPackageJson = shelljs.test("-e", appPackageJsonPath) ? JSON.parse(readFileSync(appPackageJsonPath, 'utf8')) : {};

--- a/snapshot/android/snapshot-generator.js
+++ b/snapshot/android/snapshot-generator.js
@@ -249,7 +249,7 @@ SnapshotGenerator.prototype.getSnapshotToolCommand = function (snapshotToolPath,
 
 SnapshotGenerator.prototype.getXxdCommand = function (srcOutputDir, xxdLocation) {
     // https://github.com/NativeScript/docker-images/tree/master/v8-snapshot/bin
-    return `/bin/xxd -i ${SNAPSHOT_BLOB_NAME}.blob > ${srcOutputDir}`;
+    return `${xxdLocation || ""}xxd -i ${SNAPSHOT_BLOB_NAME}.blob > ${srcOutputDir}`;
 }
 
 SnapshotGenerator.prototype.getPathInDocker = function (mappedLocalDir, mappedDockerDir, targetPath) {
@@ -310,7 +310,7 @@ SnapshotGenerator.prototype.buildCSource = function (androidArch, blobInputDir, 
         const blobsInputInDocker = `/blobs/${androidArch}`
         const srcOutputDirInDocker = `/dist/src/${androidArch}`;
         const outputPathInDocker = this.getPathInDocker(srcOutputDir, srcOutputDirInDocker, join(srcOutputDir, `${SNAPSHOT_BLOB_NAME}.c`));
-        const buildCSourceCommand = this.getXxdCommand(outputPathInDocker);
+        const buildCSourceCommand = this.getXxdCommand(outputPathInDocker, "/bin/");
         command = `docker run --rm -v "${blobInputDir}:${blobsInputInDocker}" -v "${srcOutputDir}:${srcOutputDirInDocker}" ${SNAPSHOTS_DOCKER_IMAGE} /bin/sh -c "cd ${blobsInputInDocker} && ${buildCSourceCommand}"`;
     }
     else {
@@ -377,6 +377,6 @@ SnapshotGenerator.prototype.runMksnapshotTool = function (tool, mksnapshotParams
         This is why the *.blob files are initially named  TNSSnapshot.blob. 
         After the xxd step, they must be renamed to snapshot.blob, because this is the filename that the Android runtime is looking for.
         */
-       shelljs.mv(join(blobOutputDir, `${SNAPSHOT_BLOB_NAME}.blob`), join(blobOutputDir, `snapshot.blob`));
+        shelljs.mv(join(blobOutputDir, `${SNAPSHOT_BLOB_NAME}.blob`), join(blobOutputDir, `snapshot.blob`));
     });
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Providing the `--env.snapshot` flag on Windows is throwing an exception.

## What is the new behavior?
The `--env.snapshot` flag is valid on Windows and it is generating snapshots in a docker container.

Related to: https://github.com/NativeScript/nativescript-dev-webpack/issues/1054 and https://github.com/NativeScript/nativescript-cli/pull/5037
