### PR TITLE
fix: exclude files from tests folder from built application

### DIFF
--- a/bundle-config-loader.spec.ts
+++ b/bundle-config-loader.spec.ts
@@ -39,6 +39,9 @@ const defaultTestFiles = {
     "./_app-variables.scss": false,   // do not include scss partial files
     "./App_Resources/Android/src/main/res/values/colors.xml": false,    // do not include App_Resources
     "./App_Resources/Android/src/main/AndroidManifest.xml": false,      // do not include App_Resources
+    "./tests/example.js": false,                  // do not include files from tests folder
+    "./tests/component1/model1/file1.js": false,  // do not include files from tests folder
+    "./components/tests/example.js": true,
 };
 
 const loaderOptionsWithIgnore = {

--- a/bundle-config-loader.ts
+++ b/bundle-config-loader.ts
@@ -3,8 +3,8 @@ import { loader } from "webpack";
 import { getOptions } from "loader-utils";
 import * as escapeRegExp from "escape-string-regexp";
 
-// Matches all source, markup and style files that are not in App_Resources
-const defaultMatch = "(?<!\\bApp_Resources\\b.*)\\.(xml|css|js|(?<!\\.d\\.)ts|(?<!\\b_[\\w-]*\\.)scss)$";
+// Matches all source, markup and style files that are not in App_Resources and in tests folder
+const defaultMatch = "(?<!\\bApp_Resources\\b.*)(?<!\\.\\/\\btests\\b\\/.*?)\\.(xml|css|js|(?<!\\.d\\.)ts|(?<!\\b_[\\w-]*\\.)scss)$";
 
 const loader: loader.Loader = function (source, map) {
     let {


### PR DESCRIPTION
Currently unit tests files and their dependencies are always included in the built application regardless if `tns test` or another command is executed. This way the size of built package is increased as all unit test related dependencies are included (such as mocha, chai, angularTestBed and their dependencies as well).

Rel to https://github.com/NativeScript/nativescript-dev-webpack/issues/1041

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla