### PR TITLE
refactor: emit warning for invalid & in XML

### DIFF
--- a/xml-namespace-loader.ts
+++ b/xml-namespace-loader.ts
@@ -103,8 +103,17 @@ const loader: loader.Loader = function (source: string, map) {
 
     saxParser.onopentag = (node: QualifiedTag) => { handleOpenTag(node.uri, node.local); };
     saxParser.onerror = (err) => {
+        // Do only warning about invalid character "&"" for back-compatibility
+        // as it is common to use it in a binding expression
+        if (err && 
+            err.message.indexOf("Invalid character") >= 0 && 
+            err.message.indexOf("Char: &") >= 0) {
+            this.emitWarning(err)
+        } else {
+            callbackWrapper(err);
+        }
+
         saxParser.error = null;
-        callbackWrapper(err);
     };
     saxParser.write(source).close();
 


### PR DESCRIPTION
## PR Checklist

- [x]  The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [x] Tests for the changes are included.

## What is the current behavior?
`xml-namespace-loader` throws error when encounters `&` in attribute value.

## What is the new behavior?
`xml-namespace-loader` will only emit warning in this case. Having `&&` in an attribute value might happen if you have a binding expression.
