### PR TITLE
feat: support @nativescript scope in host  resover

### DIFF
--- a/host/resolver.ts
+++ b/host/resolver.ts
@@ -3,7 +3,7 @@ import { statSync } from "fs";
 
 export function getResolver(platforms: string[], explicitResolve?: string[], nsPackageFilters?: string[], platformSpecificExt?: string[]) {
     explicitResolve = explicitResolve || [];
-    nsPackageFilters = nsPackageFilters || ['nativescript', 'tns', 'ns'];
+    nsPackageFilters = nsPackageFilters || ['nativescript', 'tns', 'ns', '@nativescript'];
     platformSpecificExt = platformSpecificExt || [".ts", ".js", ".scss", ".less", ".css", ".html", ".xml", ".vue", ".json"];
 
     return function (path: string) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Nativescript host resolver (used in angular projects) does not recognize package in `@nativescript` scope as "nativescript" packages and so does not resolve platform-specific files in there.

## What is the new behavior?
`"@nativescript"` added in host resolver's list of nativescript packages.
