### PR TITLE
fix: stop relying on semver as it could be missing in the root node_modules

### DIFF
--- a/lib/before-checkForChanges.js
+++ b/lib/before-checkForChanges.js
@@ -1,10 +1,10 @@
 const { shouldSnapshot, isWinOS } = require("./utils");
-const semver = require("semver");
 
 module.exports = function ($staticConfig, hookArgs) {
-    const cliVersion = semver.parse($staticConfig.version);
-    const majorVersion = cliVersion && cliVersion.major;
-    const minorVersion = cliVersion && cliVersion.minor;
+    const cliVersion = $staticConfig.version || '';
+    const versionsMatch = cliVersion.match(/^(\d+)\.(\d+)\.(\d+)/);
+    const majorVersion = versionsMatch && versionsMatch[1] && +versionsMatch[1];
+    const minorVersion = versionsMatch && versionsMatch[2] && +versionsMatch[2];
 
     if (majorVersion && majorVersion < 6) {
         // check if we are using the bundle workflow or the legacy one.


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
We are relying on `semver` while it could be missing in the root node_modules

## What is the new behavior?
We are not relying on `semver`
