### PR TITLE
feat: snapshot in Docker on macOS with Android runtime 6.3.0 or higher

### DIFF
--- a/snapshot/android/project-snapshot-generator.js
+++ b/snapshot/android/project-snapshot-generator.js
@@ -179,7 +179,8 @@ ProjectSnapshotGenerator.prototype.generate = function (generationOptions) {
         androidNdkPath: generationOptions.androidNdkPath,
         mksnapshotParams: mksnapshotParams,
         snapshotInDocker: generationOptions.snapshotInDocker,
-        recommendedAndroidNdkRevision
+        recommendedAndroidNdkRevision,
+        runtimeVersion
     };
 
     return generator.generate(options).then(() => {

--- a/snapshot/android/snapshot-generator.js
+++ b/snapshot/android/snapshot-generator.js
@@ -3,6 +3,7 @@ const { dirname, relative, join, EOL } = require("path");
 const child_process = require("child_process");
 const { convertToUnixPath, warn } = require("../../lib/utils");
 const PropertiesReader = require('properties-reader');
+const semver = require("semver");
 const shelljs = require("shelljs");
 
 const { createDirectory, downloadFile, getHostOS, getHostOSArch, CONSTANTS, has32BitArch, isMacOSCatalinaOrHigher, isSubPath } = require("./utils");
@@ -36,11 +37,15 @@ module.exports = SnapshotGenerator;
 
 SnapshotGenerator.SNAPSHOT_PACKAGE_NANE = "nativescript-android-snapshot";
 
-SnapshotGenerator.prototype.shouldSnapshotInDocker = function (hostOS, targetArchs) {
+SnapshotGenerator.prototype.shouldSnapshotInDocker = function (hostOS, targetArchs, currentRuntimeVersion) {
     let shouldSnapshotInDocker = false;
+    const minRuntimeWithoutMacOSSnapshotTools = "6.3.0";
     const generateInDockerMessage = "The snapshots will be generated in a docker container.";
-    if (hostOS == CONSTANTS.WIN_OS_NAME) {
+    if (hostOS === CONSTANTS.WIN_OS_NAME) {
         console.log(`The V8 snapshot tools are not supported on Windows. ${generateInDockerMessage}`);
+        shouldSnapshotInDocker = true;
+    } else if (hostOS === CONSTANTS.MAC_OS_NAME && semver.gte(currentRuntimeVersion, minRuntimeWithoutMacOSSnapshotTools)) {
+        console.log(`Starting from Android Runtime 6.3.0, the Snapshot tools are no longer supported on macOS. ${generateInDockerMessage}`);
         shouldSnapshotInDocker = true;
     } else if (isMacOSCatalinaOrHigher() && has32BitArch(targetArchs)) {
         console.log(`Starting from macOS Catalina, the 32-bit processes are no longer supported. ${generateInDockerMessage}`);
@@ -295,7 +300,7 @@ SnapshotGenerator.prototype.generate = function (options) {
 
     this.preprocessInputFiles(options.inputFiles, preprocessedInputFile);
     const hostOS = getHostOS();
-    const snapshotInDocker = options.snapshotInDocker || this.shouldSnapshotInDocker(hostOS, options.targetArchs);
+    const snapshotInDocker = options.snapshotInDocker || this.shouldSnapshotInDocker(hostOS, options.targetArchs, options.runtimeVersion);
 
     // generates the actual .blob and .c files
     return this.generateSnapshots(


### PR DESCRIPTION
The runtime will not contain snapshot tools for macOS anymore.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

Related to: https://github.com/NativeScript/android-runtime/pull/1527