### PR TITLE
fix: stop on compilation error in typescript applications

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "copy-webpack-plugin": "~4.6.0",
     "css-loader": "~2.1.1",
     "escape-string-regexp": "1.0.5",
-    "fork-ts-checker-webpack-plugin": "1.3.0",
+    "fork-ts-checker-webpack-plugin": "2.0.0",
     "global-modules-path": "2.0.0",
     "loader-utils": "^1.2.3",
     "minimatch": "3.0.4",


### PR DESCRIPTION
We have a limitation that webpack compilation doesn't stop on error in typescript applications. That was due to the issue in `fork-ts-checker-webpack-plugin`. After merging [the PR that fixes the issue](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/pull/337) and releasing 2.0.0 version of the plugin, we can update it on our side and that way webpack compilation will stop on syntax/semantic errors within the application.

Rel to: https://github.com/NativeScript/nativescript-cli/issues/3785

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla