### PR TITLE
fix: stop ignoring the initial hot updates

### DIFF
--- a/bundle-config-loader.ts
+++ b/bundle-config-loader.ts
@@ -34,26 +34,22 @@ const loader: loader.Loader = function (source, map) {
     const hmr = `
         if (module.hot) {
             const hmrUpdate = require("nativescript-dev-webpack/hmr").hmrUpdate;
-            global.__initialHmrUpdate = true;
-            global.__hmrSyncBackup = global.__onLiveSync;
+            global.__coreModulesLiveSync = global.__onLiveSync;
 
             global.__onLiveSync = function () {
+                // handle hot updated on LiveSync
                 hmrUpdate();
             };
 
             global.hmrRefresh = function({ type, path } = {}) {
-                if (global.__initialHmrUpdate) {
-                    return;
-                }
-
+                // the hot updates are applied, ask the modules to apply the changes
                 setTimeout(() => {
-                    global.__hmrSyncBackup({ type, path });
+                    global.__coreModulesLiveSync({ type, path });
                 });
             };
 
-            hmrUpdate().then(() => {
-                global.__initialHmrUpdate = false;
-            })
+            // handle hot updated on initial app start
+            hmrUpdate();
         }
         `;
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
The initial app start is not calling the core modules' `__onLiveSync` method as it expects that the changes are already applied. However, the HMR updates and the app start are asynchronous and when the app starts before the Hot Updates, the core modules are never updated. 

## What is the new behavior?
We always call the core modules' `__onLiveSync`  in order to ensure that the hot updates will affect the app state.

Related to: https://github.com/NativeScript/worker-loader/issues/41 https://github.com/NativeScript/nativescript-dev-webpack/issues/1082