### PR TITLE
feat: stop using the proxy `tns-core-modules` package when the `@nativescript/core` is available

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,19 @@ const {
 Object.assign(exports, require("./plugins"));
 Object.assign(exports, require("./host/resolver"));
 
+exports.hasRootLevelScopedModules = function ({ projectDir }) {
+    let hasRootLevelScopedModules;
+    try {
+        const scopedModulesPackageName = '@nativescript/core';
+        require.resolve(scopedModulesPackageName, { paths: [projectDir] });
+        hasRootLevelScopedModules = true;
+    } catch (e) {
+        hasRootLevelScopedModules = false;
+    }
+
+    return hasRootLevelScopedModules;
+}
+
 exports.getAotEntryModule = function (appDirectory) {
     verifyEntryModuleDirectory(appDirectory);
 

--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -60,6 +60,17 @@ module.exports = env => {
     const isAnySourceMapEnabled = !!sourceMap || !!hiddenSourceMap;
     const externals = nsWebpack.getConvertedExternals(env.externals);
     const appFullPath = resolve(projectRoot, appPath);
+    const hasRootLevelScopedModules = nsWebpack.hasRootLevelScopedModules({ projectDir: projectRoot });
+    let coreModulesPackageName = "tns-core-modules";
+    const alias = {
+        '~': appFullPath
+    };
+
+    if (hasRootLevelScopedModules) {
+        coreModulesPackageName = "@nativescript/core";
+        alias["tns-core-modules"] = coreModulesPackageName;
+        alias["nativescript-angular"] = "@nativescript/angular";
+    }
     const appResourcesFullPath = resolve(projectRoot, appResourcesPath);
     const tsConfigName = "tsconfig.tns.json";
     const entryModule = `${nsWebpack.getEntryModule(appFullPath, platform)}.ts`;
@@ -141,14 +152,12 @@ module.exports = env => {
             extensions: [".ts", ".js", ".scss", ".css"],
             // Resolve {N} system modules from tns-core-modules
             modules: [
-                resolve(__dirname, "node_modules/tns-core-modules"),
+                resolve(__dirname, `node_modules/${coreModulesPackageName}`),
                 resolve(__dirname, "node_modules"),
-                "node_modules/tns-core-modules",
+                `node_modules/${coreModulesPackageName}`,
                 "node_modules",
             ],
-            alias: {
-                '~': appFullPath
-            },
+            alias,
             symlinks: true
         },
         resolveLoader: {

--- a/templates/webpack.config.spec.ts
+++ b/templates/webpack.config.spec.ts
@@ -30,6 +30,7 @@ const nativeScriptDevWebpack = {
     PlatformFSPlugin: EmptyClass,
     getAppPath: () => 'app',
     getEntryModule: () => 'EntryModule',
+    hasRootLevelScopedModules: () => false,
     getResolver: () => null,
     getConvertedExternals: nsWebpackIndex.getConvertedExternals,
     getSourceMapFilename: nsWebpackIndex.getSourceMapFilename,

--- a/templates/webpack.config.spec.ts
+++ b/templates/webpack.config.spec.ts
@@ -1,7 +1,6 @@
 import * as proxyquire from 'proxyquire';
 import * as nsWebpackIndex from '../index';
 import { join } from 'path';
-import { skipPartiallyEmittedExpressions } from 'typescript';
 // With noCallThru enabled, `proxyquire` will not fall back to requiring the real module to populate properties that are not mocked.
 // This allows us to mock packages that are not available in node_modules.
 // In case you want to enable fallback for a specific object, just add `'@noCallThru': false`.
@@ -357,6 +356,27 @@ describe('webpack.config.js', () => {
                     expect(terserOptions.sourceMap).toBeTruthy();
                     expect(terserOptions.terserOptions.output.semicolons).toBeFalsy();
                     expect(config.output.sourceMapFilename).toEqual(join("..", newSourceMapFolder, "[file].map"));
+                });
+            });
+
+            describe(`alias for webpack.${type}.js (${platform})`, () => {
+                it('should add alias when @nativescript/core is at the root of node_modules', () => {
+                    nativeScriptDevWebpack.hasRootLevelScopedModules = () => true;
+                    const input = getInput({ platform });
+                    const config = webpackConfig(input);
+                    expect(config.resolve.alias['tns-core-modules']).toBe('@nativescript/core');
+                    if (type === 'angular') {
+                        expect(config.resolve.alias['nativescript-angular']).toBe('@nativescript/angular');
+                    }
+                });
+                it('shouldn\'t add alias when @nativescript/core is not at the root of node_modules', () => {
+                    nativeScriptDevWebpack.hasRootLevelScopedModules = () => false;
+                    const input = getInput({ platform });
+                    const config = webpackConfig(input);
+                    expect(config.resolve.alias['tns-core-modules']).toBeUndefined();
+                    if (type === 'angular') {
+                        expect(config.resolve.alias['nativescript-angular']).toBeUndefined();
+                    }
                 });
             });
         });

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -53,6 +53,16 @@ module.exports = env => {
     const isAnySourceMapEnabled = !!sourceMap || !!hiddenSourceMap;
     const externals = nsWebpack.getConvertedExternals(env.externals);
     const appFullPath = resolve(projectRoot, appPath);
+    const hasRootLevelScopedModules = nsWebpack.hasRootLevelScopedModules({ projectDir: projectRoot });
+    let coreModulesPackageName = "tns-core-modules";
+    const alias = {
+        '~': appFullPath
+    };
+
+    if (hasRootLevelScopedModules) {
+        coreModulesPackageName = "@nativescript/core";
+        alias["tns-core-modules"] = coreModulesPackageName;
+    }
     const appResourcesFullPath = resolve(projectRoot, appResourcesPath);
 
     const entryModule = nsWebpack.getEntryModule(appFullPath, platform);
@@ -99,14 +109,12 @@ module.exports = env => {
             extensions: [".js", ".scss", ".css"],
             // Resolve {N} system modules from tns-core-modules
             modules: [
-                resolve(__dirname, "node_modules/tns-core-modules"),
+                resolve(__dirname, `node_modules/${coreModulesPackageName}`),
                 resolve(__dirname, "node_modules"),
-                "node_modules/tns-core-modules",
+                `node_modules/${coreModulesPackageName}`,
                 "node_modules",
             ],
-            alias: {
-                '~': appFullPath
-            },
+            alias,
             // resolve symlinks to symlinked modules
             symlinks: true
         },

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -56,6 +56,16 @@ module.exports = env => {
     const externals = nsWebpack.getConvertedExternals(env.externals);
 
     const appFullPath = resolve(projectRoot, appPath);
+    const hasRootLevelScopedModules = nsWebpack.hasRootLevelScopedModules({ projectDir: projectRoot });
+    let coreModulesPackageName = "tns-core-modules";
+    const alias = {
+        '~': appFullPath
+    };
+
+    if (hasRootLevelScopedModules) {
+        coreModulesPackageName = "@nativescript/core";
+        alias["tns-core-modules"] = coreModulesPackageName;
+    }
     const appResourcesFullPath = resolve(projectRoot, appResourcesPath);
 
     const entryModule = nsWebpack.getEntryModule(appFullPath, platform);
@@ -106,14 +116,12 @@ module.exports = env => {
             extensions: [".ts", ".js", ".scss", ".css"],
             // Resolve {N} system modules from tns-core-modules
             modules: [
-                resolve(__dirname, "node_modules/tns-core-modules"),
+                resolve(__dirname, `node_modules/${coreModulesPackageName}`),
                 resolve(__dirname, "node_modules"),
-                "node_modules/tns-core-modules",
+                `node_modules/${coreModulesPackageName}`,
                 "node_modules",
             ],
-            alias: {
-                '~': appFullPath
-            },
+            alias,
             // resolve symlinks to symlinked modules
             symlinks: true
         },

--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -59,6 +59,19 @@ module.exports = env => {
     const mode = production ? "production" : "development"
 
     const appFullPath = resolve(projectRoot, appPath);
+    const hasRootLevelScopedModules = nsWebpack.hasRootLevelScopedModules({ projectDir: projectRoot });
+    let coreModulesPackageName = "tns-core-modules";
+    const alias = {
+        '~': appFullPath,
+        '@': appFullPath,
+        'vue': 'nativescript-vue'
+    };
+
+    if (hasRootLevelScopedModules) {
+        coreModulesPackageName = "@nativescript/core";
+        alias["tns-core-modules"] = coreModulesPackageName;
+    }
+
     const appResourcesFullPath = resolve(projectRoot, appResourcesPath);
 
     const entryModule = nsWebpack.getEntryModule(appFullPath, platform);
@@ -106,16 +119,12 @@ module.exports = env => {
             extensions: [".vue", ".ts", ".js", ".scss", ".css"],
             // Resolve {N} system modules from tns-core-modules
             modules: [
-                resolve(__dirname, "node_modules/tns-core-modules"),
+                resolve(__dirname, `node_modules/${coreModulesPackageName}`),
                 resolve(__dirname, "node_modules"),
-                "node_modules/tns-core-modules",
+                `node_modules/${coreModulesPackageName}`,
                 "node_modules",
             ],
-            alias: {
-                '~': appFullPath,
-                '@': appFullPath,
-                'vue': 'nativescript-vue'
-            },
+            alias,
             // resolve symlinks to symlinked modules
             symlinks: true,
         },


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
It's not possible to use the plugin without the `tns-core-modules` proxy package because we inject `tns-core-modules` require statements in the app.

## What is the new behavior?
The plugin injects the require statements based on the `@nativescript/core` package availability.

#### P.S. The PR is based on the @DickSmith's proposal in [this PR](https://github.com/NativeScript/nativescript-dev-webpack/pull/1088/files) with two additional improvements.
1) The code is meant to be backward compatible (it should work with core modules before 6.2.0.)
2) The "short imports" syntax is also supported in the "scoped packages only" flow.

Related to: https://github.com/NativeScript/nativescript-dev-webpack/issues/1089