### PR TITLE
fix: bundle emitted on save without changes

### DIFF
--- a/plugins/GenerateNativeScriptEntryPointsPlugin.js
+++ b/plugins/GenerateNativeScriptEntryPointsPlugin.js
@@ -1,5 +1,5 @@
 const { convertToUnixPath } = require("../lib/utils");
-const { RawSource } = require("webpack-sources");
+const { RawSource, ConcatSource } = require("webpack-sources");
 const { getPackageJson } = require("../projectHelpers");
 const { SNAPSHOT_ENTRY_NAME } = require("./NativeScriptSnapshotPlugin");
 const path = require("path");
@@ -83,7 +83,12 @@ exports.GenerateNativeScriptEntryPointsPlugin = (function () {
                     return `require("./${depRelativePathUnix}");`;
                 }).join("");
                 const currentEntryFileContent = compilation.assets[filePath].source();
-                compilation.assets[filePath] = new RawSource(`${requireDeps}${currentEntryFileContent}`);
+
+                if(compilation.assets[filePath] instanceof ConcatSource) {
+                    compilation.assets[filePath].children.unshift(`${requireDeps}`);
+                } else {
+                    compilation.assets[filePath] = new RawSource(`${requireDeps}${currentEntryFileContent}`);
+                }
             }
         });
     }


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes https://github.com/NativeScript/nativescript-dev-webpack/issues/1096

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.
`test cli-misc`: 
`test cli-build`: Test for `tns build` on emulators/simulators
`test cli-device`: Test for `tns run` on real devices
`test cli-debug`: Tests for `tns debug`
`test cli-run`: Tests for `tns run`
-->

[CLA]: http://www.nativescript.org/cla
