### PR TITLE
fix: fix module import of local css files

### DIFF
--- a/css2json-loader.spec.ts
+++ b/css2json-loader.spec.ts
@@ -38,7 +38,7 @@ describe("css2jsonLoader", () => {
 
             const loaderContext = {
                 callback: (error, source: string, map) => {
-                    expect(source).toContain(`global.registerModule("custom.css", () => require("custom.css"))`);
+                    expect(source).toContain(`global.registerModule("./custom.css", () => require("./custom.css"))`);
                     expect(source).toContain(`{"type":"declaration","property":"background-color","value":"#7f9"}`);
 
                     done();
@@ -52,7 +52,7 @@ describe("css2jsonLoader", () => {
     it("inlines css2json loader in imports if option is provided", (done) => {
         const loaderContext = {
             callback: (error, source: string, map) => {
-                expect(source).toContain(`global.registerModule("custom.css", () => require("!nativescript-dev-webpack/css2json-loader?useForImports!custom.css"))`);
+                expect(source).toContain(`global.registerModule("./custom.css", () => require("!nativescript-dev-webpack/css2json-loader?useForImports!./custom.css"))`);
                 expect(source).toContain(`{"type":"declaration","property":"background-color","value":"#7f9"}`);
 
                 done();

--- a/css2json-loader.ts
+++ b/css2json-loader.ts
@@ -1,6 +1,6 @@
 import { parse, Import, Stylesheet } from "css";
 import { loader } from "webpack";
-import { getOptions } from "loader-utils";
+import { getOptions, urlToRequest } from "loader-utils";
 
 const betweenQuotesPattern = /('|")(.*?)\1/;
 const unpackUrlPattern = /url\(([^\)]+)\)/;
@@ -53,7 +53,7 @@ function extractUrlFromRule(importRule: Import): string {
 function createRequireUri(uri): { uri: string, requireURI: string } {
     return {
         uri: uri,
-        requireURI: uri[0] === "~" && uri[1] !== "/" ? uri.substr(1) : uri
+        requireURI: urlToRequest(uri)
     };
 }
 


### PR DESCRIPTION
There is an issue when importing local css file as module as the `css2json-loader` handles it as a module instead of a local file. So, the webpack throws an error that it is not able to find the module. This PR fixes this issue as changing the method used to get the correct file uri with the method used by `css-loader` itself - https://github.com/webpack-contrib/css-loader/blob/967fb66da2545f04055eb0900a69f86e484dd842/src/utils.js#L220.

Rel to: https://github.com/NativeScript/nativescript-dev-webpack/issues/1098

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.
`test cli-misc`: 
`test cli-build`: Test for `tns build` on emulators/simulators
`test cli-device`: Test for `tns run` on real devices
`test cli-debug`: Tests for `tns debug`
`test cli-run`: Tests for `tns run`
-->

[CLA]: http://www.nativescript.org/cla
