### PR TITLE
fix: add missing tsconfig paths when the app is using only scoped core modules and Angular

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,18 +11,42 @@ Object.assign(exports, require("./plugins"));
 Object.assign(exports, require("./host/resolver"));
 
 exports.processTsPathsForScopedModules = function ({ compilerOptions }) {
-    return replacePathInCompilerOptions({
+    const tnsModulesOldPackage = "tns-core-modules";
+    const tnsModulesNewPackage = "@nativescript/core";
+    replacePathInCompilerOptions({
         compilerOptions,
-        targetPath: "tns-core-modules",
-        replacementPath: "@nativescript/core"
+        targetPath: tnsModulesOldPackage,
+        replacementPath: tnsModulesNewPackage
+    });
+    ensurePathInCompilerOptions({
+        compilerOptions,
+        sourcePath: tnsModulesOldPackage,
+        destinationPath: `./node_modules/${tnsModulesNewPackage}`
+    });
+    ensurePathInCompilerOptions({
+        compilerOptions,
+        sourcePath: `${tnsModulesOldPackage}/*`,
+        destinationPath: `./node_modules/${tnsModulesNewPackage}/*`
     });
 }
 
 exports.processTsPathsForScopedAngular = function ({ compilerOptions }) {
-    return replacePathInCompilerOptions({
+    const nsAngularOldPackage = "nativescript-angular";
+    const nsAngularNewPackage = "@nativescript/angular";
+    replacePathInCompilerOptions({
         compilerOptions,
-        targetPath: "nativescript-angular",
-        replacementPath: "@nativescript/angular"
+        targetPath: nsAngularOldPackage,
+        replacementPath: nsAngularNewPackage
+    });
+    ensurePathInCompilerOptions({
+        compilerOptions,
+        sourcePath: nsAngularOldPackage,
+        destinationPath: `./node_modules/${nsAngularNewPackage}`
+    });
+    ensurePathInCompilerOptions({
+        compilerOptions,
+        sourcePath: `${nsAngularOldPackage}/*`,
+        destinationPath: `./node_modules/${nsAngularNewPackage}/*`
     });
 }
 
@@ -214,5 +238,16 @@ function replacePathInCompilerOptions({ compilerOptions, targetPath, replacement
                 }
             }
         }
+    }
+}
+
+function ensurePathInCompilerOptions({ compilerOptions, sourcePath, destinationPath }) {
+    const paths = (compilerOptions && compilerOptions.paths) || {};
+    if (paths[sourcePath]) {
+        if (Array.isArray(paths[sourcePath]) && paths[sourcePath].indexOf(destinationPath) === -1) {
+            paths[sourcePath].push(destinationPath);
+        }
+    } else {
+        paths[sourcePath] = [destinationPath];
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-dev-webpack",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "index",
   "description": "",
   "homepage": "http://www.telerik.com",


### PR DESCRIPTION
The `AngularCompilerPlugin` is using these paths for resolving the Webpack modules similar to the `alias` array in the other flavors.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

Related to: https://github.com/NativeScript/nativescript-angular/issues/2058