### PR TITLE
fix: stop looking for local snapshot artefacts when the native prepare is skipped

### DIFF
--- a/lib/after-prepare.js
+++ b/lib/after-prepare.js
@@ -12,7 +12,12 @@ module.exports = function (hookArgs) {
 		release: hookArgs.prepareData.release
 	};
 
-	if (env.snapshot && shouldSnapshot(shouldSnapshotOptions)) {
+	if (env.snapshot &&
+		shouldSnapshot(shouldSnapshotOptions) &&
+		(!hookArgs.prepareData ||
+			!hookArgs.prepareData.nativePrepare ||
+			!hookArgs.prepareData.nativePrepare.skipNativePrepare)) {
+
 		installSnapshotArtefacts(hookArgs.prepareData.projectDir);
 	}
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,6 @@
 const os = require("os");
+const { dirname } = require("path");
+const { existsSync, mkdirSync } = require("fs");
 const { isAndroid } = require("../projectHelpers");
 
 function shouldSnapshot(config) {
@@ -21,9 +23,19 @@ function warn(message) {
     }
 }
 
+function ensureDirectoryExistence(filePath) {
+    var dir = dirname(filePath);
+    if (existsSync(dir)) {
+        return true;
+    }
+    ensureDirectoryExistence(dir);
+    mkdirSync(dir);
+}
+
 module.exports = {
     shouldSnapshot,
     convertToUnixPath,
     isWinOS,
-    warn
+    warn,
+    ensureDirectoryExistence
 };

--- a/plugins/NativeScriptSnapshotPlugin/index.js
+++ b/plugins/NativeScriptSnapshotPlugin/index.js
@@ -1,5 +1,5 @@
-const { relative, resolve, join } = require("path");
-const { closeSync, openSync, writeFileSync } = require("fs");
+const { relative, resolve, join, dirname } = require("path");
+const { closeSync, openSync, writeFileSync, existsSync, mkdirSync } = require("fs");
 const validateOptions = require("schema-utils");
 
 const ProjectSnapshotGenerator = require("../../snapshot/android/project-snapshot-generator");
@@ -57,6 +57,7 @@ exports.NativeScriptSnapshotPlugin = (function () {
         snapshotEntryContent += [...requireModules, ...internalRequireModules]
             .map(mod => `require('${mod}')`).join(";");
 
+        ensureDirectoryExistence(snapshotEntryPath);
         writeFileSync(snapshotEntryPath, snapshotEntryContent, { encoding: "utf8" });
 
         // add the module to the entry points to make sure it's content is evaluated
@@ -67,6 +68,15 @@ exports.NativeScriptSnapshotPlugin = (function () {
 
         // ensure that the runtime is installed only in the snapshotted chunk
         webpackConfig.optimization.runtimeChunk = { name: SNAPSHOT_ENTRY_NAME };
+    }
+
+    function ensureDirectoryExistence(filePath) {
+        var dir = dirname(filePath);
+        if (existsSync(dir)) {
+            return true;
+        }
+        ensureDirectoryExistence(dir);
+        mkdirSync(dir);
     }
 
     NativeScriptSnapshotPlugin.getInternalRequireModules = function (webpackContext) {

--- a/plugins/NativeScriptSnapshotPlugin/index.js
+++ b/plugins/NativeScriptSnapshotPlugin/index.js
@@ -1,5 +1,5 @@
-const { relative, resolve, join, dirname } = require("path");
-const { closeSync, openSync, writeFileSync, existsSync, mkdirSync } = require("fs");
+const { relative, resolve, join } = require("path");
+const { closeSync, openSync, writeFileSync } = require("fs");
 const validateOptions = require("schema-utils");
 
 const ProjectSnapshotGenerator = require("../../snapshot/android/project-snapshot-generator");
@@ -8,6 +8,7 @@ const {
     ANDROID_PROJECT_DIR,
     ANDROID_APP_PATH,
 } = require("../../androidProjectHelpers");
+const { ensureDirectoryExistence } = require("../../lib/utils");
 const schema = require("./options.json");
 
 const SNAPSHOT_ENTRY_NAME = "snapshot-entry";
@@ -69,16 +70,6 @@ exports.NativeScriptSnapshotPlugin = (function () {
         // ensure that the runtime is installed only in the snapshotted chunk
         webpackConfig.optimization.runtimeChunk = { name: SNAPSHOT_ENTRY_NAME };
     }
-
-    function ensureDirectoryExistence(filePath) {
-        var dir = dirname(filePath);
-        if (existsSync(dir)) {
-            return true;
-        }
-        ensureDirectoryExistence(dir);
-        mkdirSync(dir);
-    }
-
     NativeScriptSnapshotPlugin.getInternalRequireModules = function (webpackContext) {
         const packageJson = getPackageJson(webpackContext);
         return (packageJson && packageJson["android"] && packageJson["android"]["requireModules"]) || [];


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
1) navigate to any nativescript application (e.g. an empty js app)
2) `rm -rf platforms`
3) install the nativescript-cloud extension
4) `tns login`
5) `tns cloud run android --release --key-store.... --env.snapshot`
6) `enoent` exception will be thrown.

Related to https://github.com/NativeScript/nativescript-dev-webpack/issues/1118