### PR TITLE
feat(platforms): Add support for custom platform plugins

### DIFF
--- a/bundle-config-loader.ts
+++ b/bundle-config-loader.ts
@@ -10,6 +10,7 @@ const loader: loader.Loader = function (source, map) {
     let {
         angular = false,
         loadCss = true,
+        platform,
         unitTesting,
         projectRoot,
         appFullPath,
@@ -53,8 +54,14 @@ const loader: loader.Loader = function (source, map) {
         }
         `;
 
+    let sourceModule = "tns-core-modules";
+
+    if (platform !== "ios" && platform !== "android") {
+        sourceModule = `nativescript-platform-${platform}`;
+    }
+
     source = `
-        require("tns-core-modules/bundle-entry-points");
+        require("${sourceModule}/bundle-entry-points");
         ${source}
     `;
 

--- a/bundle-config-loader.ts
+++ b/bundle-config-loader.ts
@@ -56,7 +56,7 @@ const loader: loader.Loader = function (source, map) {
 
     let sourceModule = "tns-core-modules";
 
-    if (platform !== "ios" && platform !== "android") {
+    if (platform && platform !== "ios" && platform !== "android") {
         sourceModule = `nativescript-platform-${platform}`;
     }
 

--- a/index.js
+++ b/index.js
@@ -103,6 +103,8 @@ exports.getAppPath = (platform, projectDir) => {
         return `platforms/ios/${sanitizedName}/app`;
     } else if (isAndroid(platform)) {
         return ANDROID_APP_PATH;
+    } else if (hasPlatformPlugin(projectDir, platform)) {
+        return `platforms/${platform}/app`;
     } else {
         throw new Error(`Invalid platform: ${platform}`);
     }
@@ -190,6 +192,13 @@ const sanitize = name => name
     .split("")
     .filter(char => /[a-zA-Z0-9]/.test(char))
     .join("");
+
+function hasPlatformPlugin(appDirectory, platform) {
+    const packageJsonSource = getPackageJson(appDirectory);
+    const { dependencies } = packageJsonSource;
+
+    return !!dependencies[`nativescript-platform-${platform}`];
+}
 
 function getPackageJsonEntry(appDirectory) {
     const packageJsonSource = getPackageJson(appDirectory);

--- a/plugins/PlatformFSPlugin.ts
+++ b/plugins/PlatformFSPlugin.ts
@@ -101,25 +101,21 @@ export function mapFileSystem(args: MapFileSystemArgs): any {
         const {dir, name, ext} = parseFile(file);
         let platformFilePath = join(dir, `${name}.${platform}${ext}`);
 
-        try {
-            require.resolve(platformFilePath);
-        } catch (e) {
-            if (isExternal && dir.indexOf("/@nativescript/core/") !== -1) {
-                let replacedPath;
-                try {
-                    replacedPath = dir.replace(
-                        /node_modules(\/[^/]+)?\/@nativescript\/core/,
-                        `node_modules/nativescript-platform-${platform}`
-                    );
+        if (isExternal && dir.indexOf("/@nativescript/core/") !== -1) {
+            let replacedPath;
+            try {
+                replacedPath = dir.replace(
+                    /node_modules(\/[^/]+)?\/@nativescript\/core/,
+                    `node_modules/nativescript-platform-${platform}`
+                );
 
-                    platformFilePath = require.resolve(join(replacedPath, `${name}.${platform}${ext}`));
-                } catch (e) {
-                    if (replacedPath) {
-                        if (ext === ".d") {
-                            platformFilePath = undefined;
-                        } else {
-                            platformFilePath = join(replacedPath, `${name}${ext}`);
-                        }
+                platformFilePath = require.resolve(join(replacedPath, `${name}.${platform}${ext}`));
+            } catch (e) {
+                if (replacedPath) {
+                    if (ext === ".d") {
+                        platformFilePath = undefined;
+                    } else {
+                        platformFilePath = join(replacedPath, `${name}${ext}`);
                     }
                 }
             }

--- a/plugins/PlatformFSPlugin.ts
+++ b/plugins/PlatformFSPlugin.ts
@@ -8,7 +8,7 @@ export interface PlatformFSPluginOptions {
     platform?: string;
 
     /**
-     * A list of all platforms. By default it is `["ios", "android"]`.
+     * A list of all platforms. By default it is `["ios", "android", "desktop"]`.
      */
     platforms?: string[];
 
@@ -18,6 +18,8 @@ export interface PlatformFSPluginOptions {
     ignore?: string[];
 }
 
+const internalPlatforms = ["ios", "android"];
+
 export class PlatformFSPlugin {
     protected readonly platform: string;
     protected readonly platforms: ReadonlyArray<string>;
@@ -26,7 +28,7 @@ export class PlatformFSPlugin {
 
     constructor({ platform, platforms, ignore }: PlatformFSPluginOptions) {
         this.platform = platform || "";
-        this.platforms = platforms || ["ios", "android"];
+        this.platforms = platforms || internalPlatforms;
         this.ignore = ignore || [];
     }
 
@@ -58,6 +60,8 @@ export function mapFileSystem(args: MapFileSystemArgs): any {
     const fs = compiler.inputFileSystem;
     ignore = args.ignore || [];
 
+    const isExternal = internalPlatforms.indexOf(platform) === -1;
+
     const minimatchFileFilters = ignore.map(pattern => {
         const minimatchFilter = minimatch.filter(pattern);
         return file => minimatchFilter(relative(context, file));
@@ -80,7 +84,7 @@ export function mapFileSystem(args: MapFileSystemArgs): any {
             return join(dir, name.substr(0, name.length - currentPlatformExt.length) + ext);
         }
         return file;
-    }
+    };
 
     const isNotIgnored = file => !isIgnored(file);
 
@@ -95,7 +99,32 @@ export function mapFileSystem(args: MapFileSystemArgs): any {
 
     function platformSpecificFile(file: string): string {
         const {dir, name, ext} = parseFile(file);
-        const platformFilePath = join(dir, `${name}.${platform}${ext}`);
+        let platformFilePath = join(dir, `${name}.${platform}${ext}`);
+
+        try {
+            require.resolve(platformFilePath);
+        } catch (e) {
+            if (isExternal && dir.indexOf("/@nativescript/core/") !== -1) {
+                let replacedPath;
+                try {
+                    replacedPath = dir.replace(
+                        /node_modules(\/[^/]+)?\/@nativescript\/core/,
+                        `node_modules/nativescript-platform-${platform}`
+                    );
+
+                    platformFilePath = require.resolve(join(replacedPath, `${name}.${platform}${ext}`));
+                } catch (e) {
+                    if (replacedPath) {
+                        if (ext === ".d") {
+                            platformFilePath = undefined;
+                        } else {
+                            platformFilePath = join(replacedPath, `${name}${ext}`);
+                        }
+                    }
+                }
+            }
+        }
+
         return platformFilePath;
     }
 

--- a/templates/webpack.angular.js
+++ b/templates/webpack.angular.js
@@ -24,7 +24,7 @@ module.exports = env => {
         "tns-core-modules/ui/frame/activity",
     ]);
 
-    const platform = env && (env.android && "android" || env.ios && "ios");
+    const platform = env && (env.android && "android" || env.ios && "ios" || env.platform);
     if (!platform) {
         throw new Error("You need to provide a target platform!");
     }

--- a/templates/webpack.javascript.js
+++ b/templates/webpack.javascript.js
@@ -18,13 +18,17 @@ module.exports = env => {
         "tns-core-modules/ui/frame/activity",
     ]);
 
-    const platform = env && (env.android && "android" || env.ios && "ios");
+    const platform = env && (env.android && "android" || env.ios && "ios" || env.platform);
     if (!platform) {
         throw new Error("You need to provide a target platform!");
     }
 
     const platforms = ["ios", "android"];
     const projectRoot = __dirname;
+
+    if (env.platform) {
+        platforms.push(env.platform);
+    }
 
     // Default destination inside platforms/<platform>/...
     const dist = resolve(projectRoot, nsWebpack.getAppPath(platform, projectRoot));

--- a/templates/webpack.typescript.js
+++ b/templates/webpack.typescript.js
@@ -20,13 +20,17 @@ module.exports = env => {
         "tns-core-modules/ui/frame/activity",
     ]);
 
-    const platform = env && (env.android && "android" || env.ios && "ios");
+    const platform = env && (env.android && "android" || env.ios && "ios" || env.platform);
     if (!platform) {
         throw new Error("You need to provide a target platform!");
     }
 
     const platforms = ["ios", "android"];
     const projectRoot = __dirname;
+
+    if (env.platform) {
+        platforms.push(env.platform);
+    }
 
     // Default destination inside platforms/<platform>/...
     const dist = resolve(projectRoot, nsWebpack.getAppPath(platform, projectRoot));

--- a/templates/webpack.vue.js
+++ b/templates/webpack.vue.js
@@ -22,13 +22,17 @@ module.exports = env => {
         "tns-core-modules/ui/frame/activity",
     ]);
 
-    const platform = env && (env.android && "android" || env.ios && "ios");
+    const platform = env && (env.android && "android" || env.ios && "ios" || env.platform);
     if (!platform) {
         throw new Error("You need to provide a target platform!");
     }
 
     const platforms = ["ios", "android"];
     const projectRoot = __dirname;
+
+    if (env.platform) {
+        platforms.push(env.platform);
+    }
 
     // Default destination inside platforms/<platform>/...
     const dist = resolve(projectRoot, nsWebpack.getAppPath(platform, projectRoot));

--- a/xml-namespace-loader.ts
+++ b/xml-namespace-loader.ts
@@ -100,13 +100,15 @@ const loader: loader.Loader = function (source: string, map) {
     // Register ios and android prefixes as namespaces to avoid "unbound xml namespace" errors
     (<any>saxParser).ns["ios"] = "http://schemas.nativescript.org/tns.xsd";
     (<any>saxParser).ns["android"] = "http://schemas.nativescript.org/tns.xsd";
+    (<any>saxParser).ns["desktop"] = "http://schemas.nativescript.org/tns.xsd";
+    (<any>saxParser).ns["web"] = "http://schemas.nativescript.org/tns.xsd";
 
     saxParser.onopentag = (node: QualifiedTag) => { handleOpenTag(node.uri, node.local); };
     saxParser.onerror = (err) => {
         // Do only warning about invalid character "&"" for back-compatibility
         // as it is common to use it in a binding expression
-        if (err && 
-            err.message.indexOf("Invalid character") >= 0 && 
+        if (err &&
+            err.message.indexOf("Invalid character") >= 0 &&
             err.message.indexOf("Char: &") >= 0) {
             this.emitWarning(err)
         } else {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Currently there is no way to plug a custom platform for a {N} app.

## What is the new behavior?
The changes allow to start Webpack-only build for custom platforms with
```bash
npx webpack --env.platform desktop --watch
```

And it will build the resources in `/platforms/${platform}/app/`

A sample platform can be https://github.com/bundyo/nativescript-platform-desktop
A sample app - https://github.com/bundyo/ns-desktop-app

Implements #1122.