### PR TITLE
fix: `The provided Android NDK is vnull while the recommended one is v21.0.6113669` error in some cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-dev-webpack",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "main": "index",
   "description": "",
   "homepage": "http://www.telerik.com",

--- a/snapshot/android/snapshot-generator.js
+++ b/snapshot/android/snapshot-generator.js
@@ -400,7 +400,11 @@ SnapshotGenerator.prototype.buildCSource = function (androidArch, blobInputDir, 
 }
 
 SnapshotGenerator.prototype.getRecommendedNdkWarning = function (localNdkRevision, recommendedAndroidNdkRevision) {
-    return `The provided Android NDK is v${localNdkRevision} while the recommended one is v${recommendedAndroidNdkRevision}`;
+    if (localNdkRevision) {
+        return `The provided Android NDK is v${localNdkRevision} while the required one is v${recommendedAndroidNdkRevision}`;
+    } else {
+        return `The provided Android NDK version is different than the required one - v${recommendedAndroidNdkRevision}`;
+    }
 }
 
 SnapshotGenerator.prototype.runMksnapshotTool = function (tool, mksnapshotParams, inputFile, snapshotInDocker, snapshotToolsPath, buildCSource) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.