### PR TITLE
feat: Add initial support for KotlinJS

### DIFF
--- a/bundle-config-loader.ts
+++ b/bundle-config-loader.ts
@@ -4,7 +4,7 @@ import { getOptions } from "loader-utils";
 import * as escapeRegExp from "escape-string-regexp";
 
 // Matches all source, markup and style files that are not in App_Resources and in tests folder
-const defaultMatch = "(?<!\\bApp_Resources\\b.*)(?<!\\.\\/\\btests\\b\\/.*?)\\.(xml|css|js|(?<!\\.d\\.)ts|(?<!\\b_[\\w-]*\\.)scss)$";
+const defaultMatch = "(?<!\\bApp_Resources\\b.*)(?<!\\.\\/\\btests\\b\\/.*?)\\.(xml|css|js|kt|(?<!\\.d\\.)ts|(?<!\\b_[\\w-]*\\.)scss)$";
 
 const loader: loader.Loader = function (source, map) {
     let {

--- a/index.js
+++ b/index.js
@@ -79,12 +79,14 @@ exports.getEntryModule = function (appDirectory, platform) {
     const entry = getPackageJsonEntry(appDirectory);
 
     const tsEntryPath = path.resolve(appDirectory, `${entry}.ts`);
+    const ktEntryPath = path.resolve(appDirectory, `${entry}.kt`);
     const jsEntryPath = path.resolve(appDirectory, `${entry}.js`);
-    let entryExists = existsSync(tsEntryPath) || existsSync(jsEntryPath);
+    let entryExists = existsSync(tsEntryPath) || existsSync(ktEntryPath) || existsSync(jsEntryPath);
     if (!entryExists && platform) {
         const platformTsEntryPath = path.resolve(appDirectory, `${entry}.${platform}.ts`);
+        const platformKtEntryPath = path.resolve(appDirectory, `${entry}.${platform}.kt`);
         const platformJsEntryPath = path.resolve(appDirectory, `${entry}.${platform}.js`);
-        entryExists = existsSync(platformTsEntryPath) || existsSync(platformJsEntryPath);
+        entryExists = existsSync(platformTsEntryPath) || existsSync(platformKtEntryPath) || existsSync(platformJsEntryPath);
     }
 
     if (!entryExists) {

--- a/index.js
+++ b/index.js
@@ -210,7 +210,7 @@ function getPackageJsonEntry(appDirectory) {
         throw new Error(`${appDirectory}/package.json must contain a 'main' attribute!`);
     }
 
-    return entry.replace(/\.js$/i, "");
+    return entry.replace(/\.js$/i, "").replace(/\.kt$/i, "");
 }
 
 function verifyEntryModuleDirectory(appDirectory) {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`.kt` extensions are not recognized

## What is the new behavior?
<!-- Describe the changes. -->
Adds the `.kt` extension to known ones, just like `.ts`

Related to: https://github.com/NativeScript/NativeScript/issues/5379

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.
`test cli-misc`: 
`test cli-build`: Test for `tns build` on emulators/simulators
`test cli-device`: Test for `tns run` on real devices
`test cli-debug`: Tests for `tns debug`
`test cli-run`: Tests for `tns run`
-->

[CLA]: http://www.nativescript.org/cla
